### PR TITLE
fix(apps): ssp_generator reads both old and new maturity-profile shapes

### DIFF
--- a/One-Page-Apps/ssp_generator.html
+++ b/One-Page-Apps/ssp_generator.html
@@ -1854,11 +1854,17 @@
                     const key = `${sourceId}||${cid}`;
                     (a.adds || []).forEach(add => {
                         const prosePart = (add.parts || []).find(p => p.name === 'statement');
+                        // Reifegrad-Text: neue Form = pt.prose, alte Form = props "statement".
+                        // Beide Formen unterstützen (siehe Gpp-ai-tool/docs/profile-maturity-contract.md).
+                        const oldStmt = (prosePart?.props || []).find(p => p && p.name === 'statement')?.value;
+                        const text = (prosePart?.prose != null && oldStmt == null)
+                            ? prosePart.prose
+                            : (oldStmt || prosePart?.prose || '');
                         if (!bpState.modifications.has(key)) bpState.modifications.set(key, []);
                         bpState.modifications.get(key).push({
                             type: 'add',
                             position: add.position || 'ending',
-                            text: prosePart?.prose || ''
+                            text
                         });
                     });
                 });


### PR DESCRIPTION
ssp_generator only read the new maturity-profile shape (statement text in
`part.prose`), so a legacy pre-migration profile (statement text in props
`"statement"`) yielded empty modification text. This adds the same old-props
fallback the other apps already use, per
`Gpp-ai-tool/docs/profile-maturity-contract.md`.

All four maturity-aware apps now handle every profile variant:

| App | New (prose+parts) | Old (props) | Base (no alters) |
|---|---|---|---|
| pruefung_ap_ar | ✅ | ✅ | ✅ no crash |
| ssp_ausfuellen | ✅ | ✅ | ✅ no crash |
| GSpp-Viewer | ✅ | ✅ | ✅ no crash |
| ssp_generator | ✅ | ✅ (this fix) | ✅ no crash |

Verified with Python replicas of each app's parser against a real new-shape
profile, a synthetic old-shape profile, and a base profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)