### PR TITLE
Fix/apps handle both profile shapes

### DIFF
--- a/One-Page-Apps/Baustein_2_Profile.html
+++ b/One-Page-Apps/Baustein_2_Profile.html
@@ -317,7 +317,7 @@ body{
       <div>
         <div class="brand-name">Baustein_2_Profile</div>
       </div>
-      <span class="brand-sub">build 0.7.1 · aggressive Mapping-Heuristik · Satz- + Control-Stats · v3-aggressive prompt</span>
+      <span class="brand-sub">build 0.8.0 · LLM-Klassifikation → G++ Anwenderkatalog-Pool → Satz-Mapping → OSCAL-Profil mit alters · v4-gpp prompt</span>
     </div>
     <div class="meta-pills">
       <span id="status-pill" class="pill">bereit</span>
@@ -414,7 +414,7 @@ body{
           <div class="card-head">
             <div class="card-title"><span class="num">01 · input</span> Baustein-PDF & G++ Katalog</div>
           </div>
-          <div class="card-desc">PDF eines BSI-Bausteins (Ed. 2023) per Drop und G++ Anwenderkatalog (default: BSI raw URL). Optional Zielobjektkategorien als JSON-Index für Stage 1.</div>
+          <div class="card-desc">PDF eines BSI-Bausteins (Ed. 2023) per Drop. G++ Anwenderkatalog (Prose-Quelle), Zielobjektkategorien (CSV) und Control-Pools werden beim Start automatisch via raw-URL geladen.</div>
 
           <div class="dropzone" id="dropzone">
             <span class="glyph">⤓</span>
@@ -424,9 +424,9 @@ body{
           </div>
 
           <div style="margin-top:14px">
-            <label style="display:block;font-size:11px;color:var(--text-tertiary);margin-bottom:4px;font-weight:500">G++ Anwenderkatalog (raw JSON-URL)</label>
+            <label style="display:block;font-size:11px;color:var(--text-tertiary);margin-bottom:4px;font-weight:500">G++ Anwenderkatalog (raw JSON-URL · Prose-Quelle für beide Pfade)</label>
             <div class="url-row">
-              <input id="cat-url" type="text" value="https://raw.githubusercontent.com/BSI-Bund/Stand-der-Technik-Bibliothek/refs/heads/main/Quellkataloge/Kernel/BSI-Stand-der-Technik-Kernel-catalog.json">
+              <input id="cat-url" type="text" value="https://raw.githubusercontent.com/BSI-Bund/Stand-der-Technik-Bibliothek/refs/heads/main/Anwenderkataloge/Grundschutz%2B%2B/Grundschutz%2B%2B-catalog.json">
               <button class="btn sm" id="btn-load-cat">⤓ laden</button>
               <button class="btn sm ghost" id="btn-upload-cat">⤴ upload</button>
               <input id="cat-file" type="file" accept="application/json" style="display:none">
@@ -437,28 +437,22 @@ body{
           </div>
 
           <div style="margin-top:14px">
-            <label style="display:block;font-size:11px;color:var(--text-tertiary);margin-bottom:4px;font-weight:500">Profile-Index (GitHub API URL einer Verzeichnis-Auflistung)</label>
+            <label style="display:block;font-size:11px;color:var(--text-tertiary);margin-bottom:4px;font-weight:500">Zielobjektkategorien (CSV) + Pools werden automatisch geladen</label>
             <div class="url-row">
-              <input id="pi-url" type="text" value="https://api.github.com/repos/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/contents/Zielobjektkategorien/profile?ref=main">
+              <input id="pi-url" type="text" value="https://raw.githubusercontent.com/BSI-Bund/Stand-der-Technik-Bibliothek/refs/heads/main/Dokumentation/namespaces/target_object_categories.csv">
               <button class="btn sm" id="btn-load-pi">⤓ laden</button>
               <button class="btn sm ghost" id="btn-upload-pi">⤴ upload</button>
-              <input id="pi-file" type="file" accept="application/json" style="display:none">
+              <input id="pi-file" type="file" accept=".csv,text/csv" style="display:none">
             </div>
             <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-quiet);letter-spacing:0.05em;margin-bottom:8px">
-              <span id="pi-info">Profile-Index nicht geladen</span>
+              <span id="pi-info">Zielobjektkategorien nicht geladen</span> · <span id="pool-info">Pools nicht geladen</span>
             </div>
-            <div style="display:grid;grid-template-columns:1fr auto;gap:8px;align-items:end">
-              <div>
-                <label style="display:block;font-size:11px;color:var(--text-tertiary);margin-bottom:4px;font-weight:500">Profil manuell wählen (überschreibt Stage 1)</label>
-                <select id="pi-pick" style="width:100%;background:var(--bg-elev-2);border:1px solid var(--border-1);color:var(--text-primary);font-family:'JetBrains Mono',monospace;font-size:11px;padding:7px 9px;border-radius:7px;outline:none">
-                  <option value="">— auto via Stage 1 —</option>
-                  <option value="__force_c2__">— force C.2 (deterministic, no LLM) —</option>
-                </select>
-              </div>
-              <div style="display:flex;flex-direction:column;gap:4px">
-                <label style="font-size:11px;color:var(--text-tertiary);font-weight:500">Schwellwert</label>
-                <input id="match-threshold" type="number" min="0" max="1" step="0.05" value="0.5" style="width:80px;background:var(--bg-elev-2);border:1px solid var(--border-1);color:var(--text-primary);font-family:'JetBrains Mono',monospace;font-size:11px;padding:7px 9px;border-radius:7px;outline:none">
-              </div>
+            <div>
+              <label style="display:block;font-size:11px;color:var(--text-tertiary);margin-bottom:4px;font-weight:500">Kategorie manuell wählen (überschreibt Stage 1)</label>
+              <select id="pi-pick" style="width:100%;background:var(--bg-elev-2);border:1px solid var(--border-1);color:var(--text-primary);font-family:'JetBrains Mono',monospace;font-size:11px;padding:7px 9px;border-radius:7px;outline:none">
+                <option value="">— auto via Stage 1 —</option>
+                <option value="__prozess__">— force PROZESS (ISMS-Pool) —</option>
+              </select>
             </div>
           </div>
         </div>
@@ -474,19 +468,19 @@ body{
           <!-- STAGE 1 PROMPT -->
           <div class="prompt-block">
             <div class="prompt-head">
-              <div class="prompt-label"><span class="stage">▶ STAGE 1</span> profile-match — PDF → passendes Profil</div>
+              <div class="prompt-label"><span class="stage">▶ STAGE 1</span> Klassifikation — PDF → Zielobjektkategorie / Prozess</div>
               <div class="prompt-actions">
                 <button class="btn sm ghost" data-reset="s1">Reset</button>
               </div>
             </div>
-            <textarea class="prompt-ta" id="prompt-s1" data-placeholders="{baustein_id},{baustein_title},{baustein_summary},{profiles}"></textarea>
+            <textarea class="prompt-ta" id="prompt-s1" data-placeholders="{baustein_id},{baustein_title},{baustein_summary},{categories}"></textarea>
             <div class="prompt-warn" id="warn-s1"></div>
           </div>
 
-          <!-- STAGE 2 PROMPT (C.1 path) -->
+          <!-- STAGE 2 PROMPT (sentence mapping) -->
           <div class="prompt-block">
             <div class="prompt-head">
-              <div class="prompt-label"><span class="stage">▶ STAGE 2 (C.1)</span> impl-req — Pro Kernel-Control: Description aus PDF</div>
+              <div class="prompt-label"><span class="stage">▶ STAGE 2</span> Satz-Mapping — PDF-Sätze → G++-Controls aus dem Pool</div>
               <div class="prompt-actions">
                 <button class="btn sm ghost" data-reset="s2">Reset</button>
               </div>
@@ -494,7 +488,7 @@ body{
             <textarea class="prompt-ta" id="prompt-s2" data-placeholders="{baustein_id},{baustein_title},{controls},{anforderungen_with_sentences}"></textarea>
             <div class="prompt-warn" id="warn-s2"></div>
             <div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-quiet);margin-top:6px;letter-spacing:0.05em">
-              C.2-Pfad (kein Profil gematcht) erzeugt impl-reqs deterministisch aus den Anforderungen — kein Modell-Call.
+              Fallback (kein Pool auflösbar) erzeugt Custom-Controls deterministisch aus den Anforderungen — kein Modell-Call.
             </div>
           </div>
 
@@ -557,7 +551,7 @@ body{
         <!-- STAGE 1 RESULT -->
         <div class="card hidden" id="s1-result">
           <div class="card-head">
-            <div class="card-title"><span class="num">▸ stage 1</span> Profil-Match</div>
+            <div class="card-title"><span class="num">▸ stage 1</span> Klassifikation</div>
             <span class="chip" id="s1-chip">—</span>
           </div>
           <div id="s1-body" class="result-section"></div>
@@ -626,18 +620,22 @@ body{
    Default prompts — production-quality. Editable in the UI; reset restores.
    ════════════════════════════════════════════════════════════════════════ */
 
-const DEFAULT_S1_PROMPT = `Du bist Senior-Auditor für BSI IT-Grundschutz und Mitautor des Grundschutz-Kompendiums. Aufgabe: Den im PDF beschriebenen System-/Asset-Typ (BSI-Baustein der Edition 2023) auf das passendste OSCAL-Profil aus der Liste abbilden. Jedes Profil definiert eine Zielobjektkategorie für den BSI Stand-der-Technik-Kernel-Katalog.
+const DEFAULT_S1_PROMPT = `Du bist Senior-Auditor für BSI IT-Grundschutz und kennst die Grundschutz++ (G++) Methodik im Detail. Aufgabe: Bestimme aus dem PDF eines BSI-Bausteins (Edition 2023), WAS für ein Objekt der Baustein beschreibt und ordne ihn der G++-Welt zu.
+
+ZWEI MÖGLICHKEITEN:
+1. ZIELOBJEKT — der Baustein beschreibt ein konkretes technisches oder organisatorisches Schutzobjekt (z.B. ein IT-System, eine Anwendung, ein Server, ein Netz, ein Gebäude, eine Nutzendengruppe, einen Dienstleister). Dann wähle GENAU EINE passende Zielobjektkategorie aus der Liste unten.
+2. PROZESS — der Baustein beschreibt einen übergreifenden ISMS-/Management-Prozess, der kein einzelnes Schutzobjekt ist (z.B. Sicherheitsmanagement, Notfallmanagement, Personal-Prozesse, Patch-/Änderungsmanagement, Audits, Risikomanagement, Sensibilisierung). Dann setze object_type="prozess" und zielobjekt_name=null.
 
 REGELN:
-- Wähle GENAU EIN Profil, das den System-/Asset-Typ aus dem Baustein am besten abdeckt.
-- Falls KEIN Profil sauber passt, setze profile_filename: null und nenne in rationale die fehlende Abdeckung. Lieber ehrlich "kein Match" als ein schiefer Match — der C.2-Pfad fängt es ab.
-- Confidence-Range strikt:
-  · 0.90+ = das Profil beschreibt exakt diesen Asset-Typ
-  · 0.70–0.89 = klare Asset-Verwandtschaft (z.B. "Container" Profil für "Kubernetes" Baustein)
-  · 0.50–0.69 = teilweise Abdeckung, dieselbe Domäne
-  · < 0.50 = nicht ausreichend, lieber null setzen
-- alternative_filenames: bis zu 3 weitere Profile, die plausibel wären (sortiert nach absteigender Eignung).
-- Rationale auf Deutsch, knapp (2–3 Sätze), benenne, woran die Asset-Entsprechung erkennbar ist.
+- Entscheide zuerst object_type ("zielobjekt" oder "prozess") aufgrund von Titel und Beschreibung.
+- Bei "zielobjekt": wähle die Kategorie, deren Definition den Baustein-Gegenstand am besten beschreibt. Nutze die Synonyme als Hinweis. Gib den Kategorie-NAMEN exakt wie in der Liste zurück.
+- Confidence strikt:
+  · 0.90+ = Definition trifft den Baustein-Gegenstand exakt
+  · 0.70–0.89 = klar dieselbe Objektart, leichte Abweichung
+  · 0.50–0.69 = plausibel, aber unsicher
+  · < 0.50 = sehr unsicher
+- alternatives: bis zu 3 weitere plausible Kategorienamen (nur bei object_type="zielobjekt"), absteigend nach Eignung.
+- rationale auf Deutsch, knapp (2–3 Sätze): woran die Zuordnung erkennbar ist.
 
 PDF-BAUSTEIN:
 ID: {baustein_id}
@@ -645,23 +643,25 @@ Titel: {baustein_title}
 Beschreibung (Abschnitt 1 der Edition 2023):
 {baustein_summary}
 
-VERFÜGBARE PROFILE:
-{profiles}
+VERFÜGBARE ZIELOBJEKTKATEGORIEN (Name — Definition — Synonyme):
+{categories}
 
 OUTPUT: JSON:
 {
-  "profile_filename": string|null,
+  "object_type": "zielobjekt" | "prozess",
+  "zielobjekt_name": string|null,
   "confidence": number,
   "rationale": string,
-  "alternative_filenames": string[]
+  "alternatives": string[]
 }`;
 
-const DEFAULT_S2_PROMPT = `Du bist Senior-Auditor für BSI IT-Grundschutz mit langjähriger Erfahrung in der Migration von Edition-2023-Bausteinen zum Stand-der-Technik-Kernel.
+const DEFAULT_S2_PROMPT = `Du bist Senior-Auditor für BSI IT-Grundschutz mit langjähriger Erfahrung in der Migration von Edition-2023-Bausteinen zum Grundschutz++ (G++) Anwenderkatalog.
 
 KONTEXT-MODELL:
+- Die unten gelisteten G++-Controls sind GENAU der Pool, der für die in Stage 1 bestimmte Zielobjektkategorie bzw. den Prozess gilt. Es sind die einzig erlaubten Mapping-Ziele.
 - Jede Anforderung aus dem Edition-2023-Baustein besteht aus mehreren Sätzen.
-- Jeder Kernel-Control ist genau EIN Satz (Statement-Prosa).
-- Deine Aufgabe: Verteile JEDEN Satz auf alle inhaltlich verwandten Kernel-Controls.
+- Jeder G++-Control hat einen Titel und eine Statement-Prosa.
+- Deine Aufgabe: Verteile JEDEN Satz auf alle inhaltlich verwandten G++-Controls aus dem Pool.
 
 KARDINAL-REGEL — DER DEFAULT IST: ES GIBT EIN MAPPING.
 - Ein normativer Satz (enthält MUSS/MÜSSEN/SOLLTE/SOLLTEN/DARF/KANN) wird grundsätzlich auf MINDESTENS EIN Control gemappt, sofern auch nur eine inhaltliche Verwandtschaft besteht.
@@ -676,8 +676,8 @@ KARDINAL-REGEL — DER DEFAULT IST: ES GIBT EIN MAPPING.
 
 VORGEHEN PRO SATZ:
 1. Identifiziere die Haupt-Thematik(en) des Satzes.
-2. Scanne die GESAMTE Control-Liste — nicht nur den Anfang oder die offensichtlichen Treffer.
-3. Liste JEDEN Control, der inhaltlich Berührungspunkte hat (auch bei nur teilweiser Überlappung).
+2. Scanne die GESAMTE G++-Control-Liste — nicht nur den Anfang oder die offensichtlichen Treffer. Der Pool ist bereits auf die richtige Zielobjektkategorie/Prozess eingegrenzt, also passt fast immer mindestens ein Control.
+3. Liste JEDEN Control, der inhaltlich Berührungspunkte hat (auch bei nur teilweiser Überlappung). Im Zweifel mappen statt verwerfen.
 4. Bei Mehrfach-Adressierung im Satz ("Es MUSS dokumentiert UND freigegeben werden") → mappe auf BEIDE Themen.
 
 WANN GILT EIN SATZ ALS UNMAPPED (Ausnahme, selten):
@@ -693,7 +693,7 @@ REGELN:
 
 BAUSTEIN: {baustein_id} – {baustein_title}
 
-KERNEL-CONTROLS (target, jeweils 1 Satz):
+G++-CONTROLS (target-Pool, jeweils Titel + Statement-Prosa):
 {controls}
 
 ANFORDERUNGEN AUS DEM BAUSTEIN MIT EINZELSÄTZEN (zu verteilen):
@@ -744,6 +744,20 @@ const DEFAULTS = {
 };
 
 /* ════════════════════════════════════════════════════════════════════════
+   Data sources — all via raw.githubusercontent.com (no GitHub-API rate limit).
+   The G++ Anwenderkatalog is the single prose source for BOTH paths:
+   Zielobjekt-Pools (zielobjekt_controls.json, keyed by category-UUID) and
+   the ISMS/Prozess-Pool (all controls listed in gpp_isms_stripped.md).
+   ════════════════════════════════════════════════════════════════════════ */
+
+const GPP_CATALOG_URL = "https://raw.githubusercontent.com/BSI-Bund/Stand-der-Technik-Bibliothek/refs/heads/main/Anwenderkataloge/Grundschutz%2B%2B/Grundschutz%2B%2B-catalog.json";
+const ZOK_CSV_URL     = "https://raw.githubusercontent.com/BSI-Bund/Stand-der-Technik-Bibliothek/refs/heads/main/Dokumentation/namespaces/target_object_categories.csv";
+const ZO_CONTROLS_URL = "https://raw.githubusercontent.com/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/main/hilfsdateien/zielobjekt_controls.json";
+const ISMS_MD_URL     = "https://raw.githubusercontent.com/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/main/hilfsdateien/gpp_isms_stripped.md";
+// href written into the assembled OSCAL profile's import (un-escaped form)
+const GPP_CATALOG_HREF = "https://raw.githubusercontent.com/BSI-Bund/Stand-der-Technik-Bibliothek/refs/heads/main/Anwenderkataloge/Grundschutz%2B%2B/Grundschutz%2B%2B-catalog.json";
+
+/* ════════════════════════════════════════════════════════════════════════
    State
    ════════════════════════════════════════════════════════════════════════ */
 
@@ -753,18 +767,21 @@ const state = {
   pdfText: "",
   baustein: null,           // { id, title, summary, requirements }
 
-  // catalog + profiles
+  // catalog (G++ Anwenderkatalog — single prose source for both paths)
   catalog: null,
   catalogSource: null,
   catalogControls: [],      // flattened [{id, title, statement, guidance, modalverb, sec_level, group}]
-  profilesList: [],         // [{name, filename, download_url, sha?}]
-  profilesSource: null,
+
+  // classification context (raw-URL loaded, no GitHub-API)
+  categories: [],           // [{uuid, name, definition, typ, kategorie, synonyme, childOf}]
+  categoriesByName: null,   // Map name(lower) → category
+  zoControlsMap: null,      // Map zielobjekt-UUID → [control-id]
+  ismsControlIds: [],       // [control-id] for the Prozess/ISMS pool
 
   // pipeline outputs
-  matchedProfile: null,     // { profile_filename, confidence, rationale, alternative_filenames }
-  matchedProfileJson: null,
-  profileControlIds: [],    // ids included by the matched profile
-  pipelineMode: null,       // "C1" or "C2"
+  classification: null,     // { object_type, zielobjekt_name, zielobjekt_uuid, confidence, rationale, alternatives }
+  poolControlIds: [],       // candidate G++ control-ids for the matched category / prozess
+  pipelineMode: null,       // "ZIELOBJEKT" | "PROZESS" | "C2" (rare custom fallback)
   implReqs: [],             // [{control_id, control_title, control_statement, control_guidance, control_modalverb, mapped_sentences, statement_prose, description, source_anforderungen, coverage, remarks, pending, error, validation}]
   sentenceMappings: [],     // C1: raw mappings from LLM, per sentence
   unmappedSentences: [],    // C1: sentences classified as context (no control mapping)
@@ -818,7 +835,7 @@ $("btn-clear-log").addEventListener("click", () => {
    Persistence + prompt textareas
    ════════════════════════════════════════════════════════════════════════ */
 
-const PROMPT_VERSION = "v3-aggressive";  // bumps when DEFAULTS change shape — invalidates user overrides
+const PROMPT_VERSION = "v4-gpp";  // bumps when DEFAULTS change shape — invalidates user overrides
 
 function loadPrefs() {
   // Migration: if stored prompt-version differs, clear stored prompt overrides so new defaults load
@@ -827,8 +844,11 @@ function loadPrefs() {
     for (const k of ["s1","s2","check"]) {
       localStorage.removeItem(`gpp.prompt.${k}`);
     }
+    // v4-gpp also retargets the data sources — drop stale Kernel/GitHub-API URLs
+    localStorage.removeItem("gpp.caturl");
+    localStorage.removeItem("gpp.piurl");
     localStorage.setItem("gpp.prompt.version", PROMPT_VERSION);
-    if (storedVer) l.info(`prompt-version migration ${storedVer} → ${PROMPT_VERSION} · stored prompts gelöscht, defaults aktiv`);
+    if (storedVer) l.info(`prompt-version migration ${storedVer} → ${PROMPT_VERSION} · stored prompts + URLs gelöscht, defaults aktiv`);
   }
 
   $("api-key").value         = localStorage.getItem("gpp.apikey")    || "";
@@ -843,7 +863,6 @@ function loadPrefs() {
   $("testdrive").checked     = localStorage.getItem("gpp.td")        === "1";
   $("cat-url").value         = localStorage.getItem("gpp.caturl")    || $("cat-url").value;
   $("pi-url").value          = localStorage.getItem("gpp.piurl")     || $("pi-url").value;
-  $("match-threshold").value = localStorage.getItem("gpp.threshold") || "0.5";
   for (const k of ["s1","s2","check"]) {
     $(`prompt-${k}`).value = localStorage.getItem(`gpp.prompt.${k}`) || DEFAULTS[k];
   }
@@ -864,7 +883,6 @@ bindPersist("chunk-size", "gpp.chunk");
 bindPersist("anf-batch", "gpp.anfbatch");
 bindPersist("cat-url", "gpp.caturl");
 bindPersist("pi-url", "gpp.piurl");
-bindPersist("match-threshold", "gpp.threshold");
 
 $("maker-checker").addEventListener("change", e => {
   localStorage.setItem("gpp.mc", e.target.checked ? "1" : "0");
@@ -1090,6 +1108,20 @@ function flattenCatalog(cat) {
     };
     for (const p of (ctl.parts || [])) collectPart(p);
 
+    // Resolve OSCAL "{{ insert: param, id }}" placeholders to their values so
+    // the prose sent to the model is clean, readable text.
+    const paramVals = new Map();
+    for (const pm of (ctl.params || [])) {
+      if (!pm?.id) continue;
+      const v = Array.isArray(pm.values) && pm.values.length ? pm.values.join(", ")
+              : (pm.select?.choice?.join(", ") || pm.label || "");
+      paramVals.set(pm.id, v);
+    }
+    const resolveParams = s => s.replace(/\{\{\s*insert:\s*param,\s*([^\s}]+)\s*\}\}/g,
+      (_, id) => paramVals.get(id) ?? `[${id}]`);
+    statement = resolveParams(statement);
+    guidance  = resolveParams(guidance);
+
     let sec_level = null;
     for (const pr of (ctl.props || [])) {
       if (pr?.name === "sec_level" && !sec_level) sec_level = pr.value;
@@ -1192,147 +1224,127 @@ function setCatalog(json, src) {
   l.ok(`catalog flattened · ${state.catalogControls.length} controls`);
 }
 
-// Profile-index loaders
+/* ════════════════════════════════════════════════════════════════════════
+   Zielobjektkategorien (CSV) + Control-Pools — all via raw URLs.
+   CSV columns: Zielobjektkategorie,Definition,Typ,Kategorie,Synonyme,ChildOfUUID,UUID
+   ════════════════════════════════════════════════════════════════════════ */
+
+// Minimal RFC-4180-ish CSV parser: handles quoted fields with commas + newlines.
+function parseCsv(text) {
+  const rows = [];
+  let row = [], field = "", inQ = false;
+  const s = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inQ) {
+      if (c === '"') {
+        if (s[i + 1] === '"') { field += '"'; i++; }
+        else inQ = false;
+      } else field += c;
+    } else if (c === '"') inQ = true;
+    else if (c === ",") { row.push(field); field = ""; }
+    else if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; }
+    else field += c;
+  }
+  if (field.length || row.length) { row.push(field); rows.push(row); }
+  return rows.filter(r => r.length && r.some(x => x.trim() !== ""));
+}
+
+function setCategories(csvText, src) {
+  const rows = parseCsv(csvText);
+  const header = rows.shift() || [];
+  const col = name => header.findIndex(h => h.trim().toLowerCase() === name.toLowerCase());
+  const ci = {
+    name: col("Zielobjektkategorie"), def: col("Definition"), typ: col("Typ"),
+    kat: col("Kategorie"), syn: col("Synonyme"), child: col("ChildOfUUID"), uuid: col("UUID"),
+  };
+  const cats = rows.map(r => ({
+    name: (r[ci.name] || "").trim(),
+    definition: (r[ci.def] || "").trim(),
+    typ: (r[ci.typ] || "").trim(),
+    kategorie: (r[ci.kat] || "").trim(),
+    synonyme: (r[ci.syn] || "").trim(),
+    childOf: (r[ci.child] || "").trim(),
+    uuid: (r[ci.uuid] || "").trim(),
+  })).filter(c => c.name && c.uuid);
+
+  state.categories = cats;
+  state.categoriesByName = new Map(cats.map(c => [c.name.toLowerCase(), c]));
+  $("pi-info").textContent = `${cats.length} Zielobjektkategorien · ${src.length > 60 ? src.slice(0,60) + "…" : src}`;
+  l.ok(`Zielobjektkategorien geladen · ${cats.length}`);
+
+  // Populate manual picker, preserving the static options
+  const sel = $("pi-pick");
+  const prev = sel.value;
+  sel.innerHTML = `<option value="">— auto via Stage 1 —</option>
+    <option value="__prozess__">— force PROZESS (ISMS-Pool) —</option>` + cats
+      .slice().sort((a, b) => a.name.localeCompare(b.name))
+      .map(c => `<option value="${escapeHtml(c.uuid)}">${escapeHtml(c.name)}</option>`).join("");
+  if (prev) sel.value = prev;
+}
+
 $("btn-upload-pi").addEventListener("click", () => $("pi-file").click());
 $("pi-file").addEventListener("change", async e => {
   const f = e.target.files?.[0];
   if (!f) return;
-  try {
-    const text = await f.text();
-    setProfilesIndex(JSON.parse(text), `file://${f.name}`);
-  } catch (err) { l.err(`profile-index file: ${err.message}`); }
+  try { setCategories(await f.text(), `file://${f.name}`); }
+  catch (err) { l.err(`Kategorien-Datei: ${err.message}`); }
 });
 
-// Fetch a GitHub "contents" listing. If it contains subdirectories (e.g.
-// .../profile → regular + process), descend one level and merge their files.
-async function fetchGithubContentsRecursive(url, depth = 0) {
-  const r = await fetch(url);
-  if (!r.ok) throw new Error(`HTTP ${r.status}` + (r.status === 403 ? " (GitHub API rate limit — gleich nochmal probieren)" : ""));
-  const json = await r.json();
-  if (!Array.isArray(json) || depth >= 2) return json;
-
-  const dirs = json.filter(e => e && e.type === "dir" && e.url);
-  if (dirs.length === 0) return json;
-
-  const files = json.filter(e => !(e && e.type === "dir"));
-  const nested = await Promise.all(dirs.map(d => {
-    l.info(`descend into ${d.name}/`);
-    return fetchGithubContentsRecursive(d.url, depth + 1).catch(e => {
-      l.warn(`subdir ${d.name} failed: ${e.message}`); return [];
-    });
-  }));
-  return files.concat(...nested.map(n => Array.isArray(n) ? n : []));
-}
-
 $("btn-load-pi").addEventListener("click", async () => {
-  const url = $("pi-url").value.trim();
-  if (!url) return l.warn("keine Profile-Index-URL angegeben");
-  l.info(`fetch profile-index · ${url}`);
+  const url = $("pi-url").value.trim() || ZOK_CSV_URL;
+  l.info(`fetch Zielobjektkategorien · ${url}`);
   try {
     const t0 = performance.now();
-    const json = await fetchGithubContentsRecursive(url);
-    setProfilesIndex(json, url);
-    l.ok(`profile-index fetched in ${Math.round(performance.now()-t0)}ms`);
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    setCategories(await r.text(), url);
+    l.ok(`Kategorien fetched in ${Math.round(performance.now()-t0)}ms`);
   } catch (e) {
-    l.err(`profile-index fetch failed: ${e.message}`);
+    l.err(`Kategorien fetch failed: ${e.message}`);
     $("pi-info").textContent = `Fehler: ${e.message}`;
   }
 });
 
-function setProfilesIndex(json, src) {
-  // Accept several shapes:
-  //  - GitHub API contents response: [{name, download_url, type, path, sha}]
-  //  - Plain array of objects: [{name, url}]
-  //  - Plain array of strings (filenames)
-  //  - Object map: { filename: url }
-  let list = [];
-  if (Array.isArray(json)) {
-    list = json.map(entry => {
-      if (typeof entry === "string") return { name: entry, filename: entry, download_url: null };
-      // GitHub API entry
-      if (entry.download_url || entry.path) {
-        return {
-          name: entry.name || entry.path?.split("/").pop(),
-          filename: entry.name || entry.path?.split("/").pop(),
-          download_url: entry.download_url || null,
-          path: entry.path,
-          type: entry.type,
-          sha: entry.sha,
-        };
-      }
-      // Custom entry
-      return {
-        name: entry.name || entry.filename,
-        filename: entry.filename || entry.name,
-        download_url: entry.download_url || entry.url || null,
-      };
-    });
-  } else if (typeof json === "object" && json !== null) {
-    list = Object.entries(json).map(([name, url]) => ({
-      name, filename: name, download_url: typeof url === "string" ? url : url?.download_url || null,
-    }));
-  }
+// Load the deterministic control pools (zielobjekt → ids) + ISMS id set.
+async function loadPools() {
+  try {
+    const t0 = performance.now();
+    const [zoRes, ismsRes] = await Promise.all([fetch(ZO_CONTROLS_URL), fetch(ISMS_MD_URL)]);
+    if (!zoRes.ok) throw new Error(`zielobjekt_controls HTTP ${zoRes.status}`);
+    if (!ismsRes.ok) throw new Error(`isms HTTP ${ismsRes.status}`);
+    const zoJson = await zoRes.json();
+    const map = zoJson?.zielobjekt_controls_map ?? zoJson;
+    state.zoControlsMap = new Map(Object.entries(map));
 
-  // Filter for .json files, exclude directories
-  list = list.filter(e => {
-    if (e.type === "dir") return false;
-    return /\.json$/i.test(e.filename || "");
-  });
-
-  state.profilesList = list;
-  state.profilesSource = src;
-  $("pi-info").textContent = list.length
-    ? `${list.length} Profile gefunden · ${src.length > 80 ? src.slice(0,80) + "…" : src}`
-    : `keine .json-Dateien im Index gefunden`;
-  l.ok(`profile-index loaded · ${list.length} entries`);
-
-  // Repopulate manual picker, preserving the static options
-  const sel = $("pi-pick");
-  const prev = sel.value;
-  sel.innerHTML = `<option value="">— auto via Stage 1 —</option>
-    <option value="__force_c2__">— force C.2 (deterministic, no LLM) —</option>` + list.map(p =>
-    `<option value="${escapeHtml(p.filename)}">${escapeHtml(prettyProfileName(p.filename))}</option>`
-  ).join("");
-  if (prev) sel.value = prev;
-}
-
-function prettyProfileName(filename) {
-  // Strip .json, replace separators, title-case
-  return filename
-    .replace(/\.json$/i, "")
-    .replace(/[_\-]/g, " ")
-    .replace(/\s{2,}/g, " ")
-    .trim();
-}
-
-/* ════════════════════════════════════════════════════════════════════════
-   Profile content loader — for the picked or matched profile
-   ════════════════════════════════════════════════════════════════════════ */
-
-async function loadProfileContent(entry) {
-  if (!entry) throw new Error("no profile entry");
-  const url = entry.download_url || entry.url;
-  if (!url) throw new Error(`profile entry ${entry.filename} has no download_url`);
-  l.debug(`fetch profile content · ${entry.filename}`);
-  const r = await fetch(url);
-  if (!r.ok) throw new Error(`HTTP ${r.status} fetching ${entry.filename}`);
-  return await r.json();
-}
-
-/** Extract control IDs from an OSCAL profile's imports section.
-    Falls back to including-by-pattern or merging all controls.   */
-function extractProfileControlIds(profileJson) {
-  const ids = new Set();
-  const prof = profileJson?.profile ?? profileJson;
-  for (const imp of (prof?.imports || [])) {
-    for (const incl of (imp?.["include-controls"] || imp?.includeControls || [])) {
-      for (const id of (incl?.["with-ids"] || incl?.withIds || [])) {
-        ids.add(id);
-      }
+    // gpp_isms_stripped.md → set of control IDs from the first table column
+    const ismsText = await ismsRes.text();
+    const ids = [];
+    for (const line of ismsText.split("\n")) {
+      const m = line.match(/^\s*\|\s*([A-Z][A-Z0-9]*(?:\.\d+)+)\s*\|/);
+      if (m) ids.push(m[1]);
     }
-    // include-all / include-by-pattern not handled fine-grained — caller can fallback
+    state.ismsControlIds = ids;
+    $("pool-info").textContent = `${state.zoControlsMap.size} ZO-Pools · ${ids.length} ISMS-Controls`;
+    l.ok(`Pools geladen in ${Math.round(performance.now()-t0)}ms · ${state.zoControlsMap.size} ZO-Pools · ${ids.length} ISMS-Controls`);
+  } catch (e) {
+    l.err(`Pool-Load fehlgeschlagen: ${e.message}`);
+    $("pool-info").textContent = `Pools Fehler: ${e.message}`;
   }
-  return [...ids];
+}
+
+// Resolve a Zielobjektkategorie name (as returned by the LLM) to a category object.
+function resolveCategory(name) {
+  if (!name || !state.categoriesByName) return null;
+  const lc = name.trim().toLowerCase();
+  let hit = state.categoriesByName.get(lc);
+  if (hit) return hit;
+  // fuzzy: contains / synonym match
+  for (const c of state.categories) {
+    if (c.name.toLowerCase().includes(lc) || lc.includes(c.name.toLowerCase())) return c;
+    if (c.synonyme && c.synonyme.toLowerCase().split(/[;,]/).some(s => s.trim() && s.trim() === lc)) return c;
+  }
+  return null;
 }
 
 /* ════════════════════════════════════════════════════════════════════════
@@ -1486,66 +1498,67 @@ function buildPrompt(key, vars) {
 }
 
 /* ════════════════════════════════════════════════════════════════════════
-   STAGE 1 — Profile match
+   STAGE 1 — Klassifikation: Zielobjektkategorie vs. Prozess (LLM)
    ════════════════════════════════════════════════════════════════════════ */
 
 const SCHEMA_S1 = {
   type: "object",
   properties: {
-    profile_filename: { type: ["string","null"] },
-    confidence:       { type: "number" },
-    rationale:        { type: "string" },
-    alternative_filenames: { type: "array", items: { type: "string" } },
+    object_type:    { type: "string", enum: ["zielobjekt","prozess"] },
+    zielobjekt_name:{ type: ["string","null"] },
+    confidence:     { type: "number" },
+    rationale:      { type: "string" },
+    alternatives:   { type: "array", items: { type: "string" } },
   },
-  required: ["profile_filename","confidence","rationale"],
+  required: ["object_type","confidence","rationale"],
 };
 
-async function runStage1ProfileMatch() {
+async function runStage1Classify() {
   setStage("s1");
-  showProgress("stage 1 · profile-match", 0, 1);
-
-  if (state.profilesList.length === 0) {
-    l.warn("kein Profile-Index geladen — Stage 1 wird übersprungen, Pipeline geht direkt in C.2-Pfad");
-    state.matchedProfile = { profile_filename: null, confidence: 0, rationale: "Kein Profile-Index geladen — fallback zu C.2 (deterministisch)." };
-    renderStage1();
-    doneStage("s1");
-    return;
-  }
+  showProgress("stage 1 · klassifikation", 0, 1);
 
   const b = state.baustein;
-  const profList = state.profilesList.map(p =>
-    `- ${p.filename}  (${prettyProfileName(p.filename)})`
-  ).join("\n");
+
+  // Build the category list as context (name — definition — synonyme)
+  const catBlock = state.categories.map(c => {
+    const def = (c.definition || "").replace(/\s+/g, " ").trim().slice(0, 320);
+    const syn = c.synonyme ? ` — Synonyme: ${c.synonyme}` : "";
+    return `- ${c.name}: ${def}${syn}`;
+  }).join("\n");
+  if (!state.categories.length) {
+    l.warn("keine Zielobjektkategorien geladen — Klassifikation läuft ohne Kategorie-Liste (nur zielobjekt/prozess möglich)");
+  }
 
   const prompt = buildPrompt("s1", {
     baustein_id: b.id || "(unbekannt)",
     baustein_title: b.title || "(unbekannt)",
     baustein_summary: (b.summary || "").slice(0, 3500),
-    profiles: profList,
+    categories: catBlock || "(keine Kategorien geladen)",
   });
 
-  const text = await llm(prompt, "s1 profile-match", $("grounding").checked ? null : SCHEMA_S1);
+  const text = await llm(prompt, "s1 klassifikation", $("grounding").checked ? null : SCHEMA_S1);
   const parsed = extractJson(text);
 
-  // Validate the match: filename must exist in profilesList
-  if (parsed.profile_filename) {
-    const exists = state.profilesList.some(p => p.filename === parsed.profile_filename);
-    if (!exists) {
-      l.warn(`Modell nannte unbekanntes Profil "${parsed.profile_filename}" — versuche, ähnlichstes zu finden`);
-      const lc = parsed.profile_filename.toLowerCase();
-      const fuzzy = state.profilesList.find(p => p.filename.toLowerCase() === lc)
-                 || state.profilesList.find(p => p.filename.toLowerCase().includes(lc.replace(/\.json$/, "")));
-      if (fuzzy) {
-        l.info(`fuzzy match: "${parsed.profile_filename}" → "${fuzzy.filename}"`);
-        parsed.profile_filename = fuzzy.filename;
-      } else {
-        parsed.profile_filename = null;
-        parsed.rationale = `(Modell halluzinierte unbekannten Dateinamen — auf null gesetzt) ${parsed.rationale}`;
-      }
+  const cls = {
+    object_type: parsed.object_type === "prozess" ? "prozess" : "zielobjekt",
+    zielobjekt_name: parsed.zielobjekt_name || null,
+    zielobjekt_uuid: null,
+    confidence: typeof parsed.confidence === "number" ? parsed.confidence : null,
+    rationale: parsed.rationale || "",
+    alternatives: Array.isArray(parsed.alternatives) ? parsed.alternatives : [],
+  };
+
+  if (cls.object_type === "zielobjekt") {
+    const cat = resolveCategory(cls.zielobjekt_name);
+    if (cat) {
+      cls.zielobjekt_uuid = cat.uuid;
+      cls.zielobjekt_name = cat.name;  // canonical
+    } else if (cls.zielobjekt_name) {
+      l.warn(`Modell nannte unbekannte Kategorie "${cls.zielobjekt_name}" — nicht in der CSV auflösbar`);
     }
   }
 
-  state.matchedProfile = parsed;
+  state.classification = cls;
   showProgress("stage 1 · done", 1, 1);
   renderStage1();
   doneStage("s1");
@@ -1555,78 +1568,83 @@ function renderStage1() {
   const card = $("s1-result");
   const body = $("s1-body");
   card.classList.remove("hidden");
-
-  // If user has manually picked a profile, show that too
-  const manual = $("pi-pick").value;
-
-  const m = state.matchedProfile || {};
-  const confPct = m.confidence != null ? Math.round(m.confidence * 100) : null;
-  const threshold = parseFloat($("match-threshold").value) || 0.5;
-
   body.innerHTML = "";
 
+  // Manual override via picker (uuid or __prozess__)
+  const manual = $("pi-pick").value;
   if (manual) {
+    const isProz = manual === "__prozess__";
+    const cat = isProz ? null : (state.categories.find(c => c.uuid === manual) || null);
     const div = document.createElement("div");
     div.className = "zo-card primary";
     div.innerHTML = `
       <div class="zo-top">
-        <div class="zo-name">${escapeHtml(prettyProfileName(manual))}</div>
+        <div class="zo-name">${escapeHtml(isProz ? "PROZESS (ISMS-Pool)" : (cat?.name || manual))}</div>
         <div class="zo-type">manual override</div>
       </div>
-      <div class="zo-rationale">Manuelle Auswahl überschreibt das Stage-1-Ergebnis. Dateiname: <code style="font-family:'JetBrains Mono',monospace;color:var(--accent)">${escapeHtml(manual)}</code></div>
+      <div class="zo-rationale">Manuelle Auswahl überschreibt die Stage-1-Klassifikation.${cat ? ` <code style="font-family:'JetBrains Mono',monospace;color:var(--accent)">${escapeHtml(cat.uuid)}</code>` : ""}</div>
     `;
     body.appendChild(div);
-    $("s1-chip").textContent = `manual: ${manual}`;
+    $("s1-chip").textContent = isProz ? "manual: PROZESS" : `manual: ${cat?.name || manual}`;
     return;
   }
 
-  const willMatch = m.profile_filename && (m.confidence == null || m.confidence >= threshold);
+  const c = state.classification || {};
+  const confPct = c.confidence != null ? Math.round(c.confidence * 100) : null;
 
-  if (m.profile_filename) {
-    const div = document.createElement("div");
-    div.className = "zo-card" + (willMatch ? " primary" : "");
+  const div = document.createElement("div");
+  if (c.object_type === "prozess") {
+    div.className = "zo-card primary";
     div.innerHTML = `
       <div class="zo-top">
-        <div class="zo-name">${escapeHtml(prettyProfileName(m.profile_filename))}</div>
-        <div class="zo-type">${willMatch ? `match (≥${threshold})` : `under threshold (${threshold})`}</div>
+        <div class="zo-name">PROZESS</div>
+        <div class="zo-type">ISMS-Pool</div>
       </div>
       <div class="zo-rationale">
-        <span style="font-family:'JetBrains Mono',monospace;font-size:10px;color:${willMatch ? "var(--green)" : "var(--amber)"};letter-spacing:0.05em">confidence: ${confPct ?? "—"}%</span><br>
-        ${escapeHtml(m.rationale || "")}<br>
-        <code style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--accent)">${escapeHtml(m.profile_filename)}</code>
+        <span style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--green);letter-spacing:0.05em">confidence: ${confPct ?? "—"}%</span><br>
+        ${escapeHtml(c.rationale || "")}
+      </div>`;
+    $("s1-chip").textContent = `PROZESS (conf ${confPct ?? "—"}%)`;
+  } else if (c.zielobjekt_uuid) {
+    div.className = "zo-card primary";
+    div.innerHTML = `
+      <div class="zo-top">
+        <div class="zo-name">${escapeHtml(c.zielobjekt_name || "?")}</div>
+        <div class="zo-type">Zielobjektkategorie</div>
       </div>
-    `;
-    body.appendChild(div);
-    $("s1-chip").textContent = willMatch ? `C.1 (conf ${confPct}%)` : `C.2 (under threshold)`;
+      <div class="zo-rationale">
+        <span style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--green);letter-spacing:0.05em">confidence: ${confPct ?? "—"}%</span><br>
+        ${escapeHtml(c.rationale || "")}<br>
+        <code style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--accent)">${escapeHtml(c.zielobjekt_uuid)}</code>
+      </div>`;
+    $("s1-chip").textContent = `ZIELOBJEKT: ${c.zielobjekt_name} (conf ${confPct ?? "—"}%)`;
   } else {
-    const div = document.createElement("div");
     div.className = "zo-card";
     div.style.borderColor = "oklch(0.65 0.2 25 / 0.3)";
     div.innerHTML = `
       <div class="zo-top">
-        <div class="zo-name">Kein Profil-Match</div>
-        <div class="zo-type" style="color:var(--red)">→ C.2-Pfad</div>
+        <div class="zo-name">${escapeHtml(c.zielobjekt_name || "Kategorie nicht auflösbar")}</div>
+        <div class="zo-type" style="color:var(--amber)">→ Kategorie manuell wählen</div>
       </div>
-      <div class="zo-rationale">${escapeHtml(m.rationale || "Pipeline geht in den deterministischen C.2-Pfad.")}</div>
-    `;
-    body.appendChild(div);
-    $("s1-chip").textContent = "C.2 (no match)";
+      <div class="zo-rationale">${escapeHtml(c.rationale || "Keine Kategorie zugeordnet.")}</div>`;
+    $("s1-chip").textContent = "kein Pool — manuell wählen";
   }
+  body.appendChild(div);
 
-  // Alternatives
-  if (Array.isArray(m.alternative_filenames) && m.alternative_filenames.length) {
-    const div = document.createElement("div");
-    div.style.marginTop = "8px";
-    div.innerHTML = `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-quiet);letter-spacing:0.1em;text-transform:uppercase;margin-bottom:6px">Alternativen</div>`;
-    for (const alt of m.alternative_filenames.slice(0, 3)) {
+  // Alternatives (zielobjekt only)
+  if (c.object_type === "zielobjekt" && Array.isArray(c.alternatives) && c.alternatives.length) {
+    const alt = document.createElement("div");
+    alt.style.marginTop = "8px";
+    alt.innerHTML = `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-quiet);letter-spacing:0.1em;text-transform:uppercase;margin-bottom:6px">Alternativen</div>`;
+    for (const a of c.alternatives.slice(0, 3)) {
       const e = document.createElement("div");
       e.className = "zo-card";
       e.style.padding = "8px 12px";
       e.style.marginBottom = "5px";
-      e.innerHTML = `<div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text-tertiary)">${escapeHtml(alt)}</div>`;
-      div.appendChild(e);
+      e.innerHTML = `<div style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text-tertiary)">${escapeHtml(a)}</div>`;
+      alt.appendChild(e);
     }
-    body.appendChild(div);
+    body.appendChild(alt);
   }
 }
 
@@ -1666,38 +1684,50 @@ function sampleForTestDrive(items, pct = 0.05, minSample = 3) {
   return picked;
 }
 
-function decidePipelineMode() {
+// Determine the candidate G++ control pool. Sets state.pipelineMode and
+// state.poolControlIds. ZIELOBJEKT → zielobjekt_controls.json[uuid];
+// PROZESS → the ISMS control set; C2 → no pool (rare custom fallback).
+function determinePool() {
   const manual = $("pi-pick").value;
-  if (manual === "__force_c2__") {
-    state.pipelineMode = "C2";
-    state.matchedProfileFilename = null;
-    return;
+  let mode, uuid = null;
+  if (manual === "__prozess__") { mode = "PROZESS"; }
+  else if (manual) { mode = "ZIELOBJEKT"; uuid = manual; }
+  else {
+    const c = state.classification;
+    if (c?.object_type === "prozess") mode = "PROZESS";
+    else if (c?.zielobjekt_uuid) { mode = "ZIELOBJEKT"; uuid = c.zielobjekt_uuid; }
+    else mode = "C2";
   }
-  if (manual) {
-    state.pipelineMode = "C1";
-    state.matchedProfileFilename = manual;
-    return;
+
+  let ids = [];
+  if (mode === "PROZESS") {
+    ids = state.ismsControlIds.slice();
+    if (!ids.length) l.warn("ISMS-Pool leer — gpp_isms_stripped.md nicht geladen?");
+  } else if (mode === "ZIELOBJEKT") {
+    ids = (state.zoControlsMap && state.zoControlsMap.get(uuid)) || [];
+    if (!ids.length) l.warn(`kein Control-Pool für Zielobjekt ${uuid} in zielobjekt_controls.json`);
   }
-  const m = state.matchedProfile;
-  const threshold = parseFloat($("match-threshold").value) || 0.5;
-  if (m?.profile_filename && (m.confidence == null || m.confidence >= threshold)) {
-    state.pipelineMode = "C1";
-    state.matchedProfileFilename = m.profile_filename;
-  } else {
-    state.pipelineMode = "C2";
-    state.matchedProfileFilename = null;
-  }
+  state.pipelineMode = mode;
+  state.poolControlIds = ids;
 }
 
 async function runStage2() {
   setStage("s2");
-  decidePipelineMode();
-  $("s2-mode-tag").textContent = state.pipelineMode;
+  determinePool();
+
+  if (state.pipelineMode !== "C2" && state.poolControlIds.length === 0) {
+    l.warn(`${state.pipelineMode}-Pool ist leer — Fallback auf C.2 (deterministische Custom-Controls)`);
+    state.pipelineMode = "C2";
+  }
+
+  const cat = state.classification?.zielobjekt_name;
+  $("s2-mode-tag").textContent = state.pipelineMode === "ZIELOBJEKT" && cat
+    ? `ZIELOBJEKT · ${cat}` : state.pipelineMode;
 
   if (state.pipelineMode === "C2") {
     await runStage2_C2_deterministic();
   } else {
-    await runStage2_C1_sentenceMapping();
+    await runStage2_SentenceMapping();
   }
 
   renderStage2();
@@ -1705,36 +1735,23 @@ async function runStage2() {
   doneStage("s2");
 }
 
-async function runStage2_C1_sentenceMapping() {
-  // 1. Load the matched profile
-  const profEntry = state.profilesList.find(p => p.filename === state.matchedProfileFilename);
-  if (!profEntry) {
-    throw new Error(`Profil "${state.matchedProfileFilename}" nicht im Index gefunden`);
-  }
-  l.info(`stage 2 (C.1) · loading profile ${profEntry.filename}`);
-  state.matchedProfileJson = await loadProfileContent(profEntry);
-
-  // 2. Extract control IDs from profile
-  let ids = extractProfileControlIds(state.matchedProfileJson);
-  if (ids.length === 0) {
-    l.warn(`profile ${profEntry.filename} listet keine expliziten control-ids — fallback: alle Kernel-Controls werden referenziert`);
-    ids = state.catalogControls.map(c => c.id);
-  }
-  state.profileControlIds = ids;
-  l.ok(`profile imports ${ids.length} control-ids from Kernel`);
-
-  // 3. Look up controls in the Kernel catalog
+async function runStage2_SentenceMapping() {
+  // 1. Resolve the candidate pool IDs to controls (title + full prose) from the
+  //    G++ Anwenderkatalog.
+  const ids = state.poolControlIds;
+  l.info(`stage 2 (${state.pipelineMode}) · Pool mit ${ids.length} G++-Controls`);
   const controlsById = new Map(state.catalogControls.map(c => [c.id, c]));
   const controls = ids.map(id => controlsById.get(id)).filter(Boolean);
   const missing = ids.filter(id => !controlsById.has(id));
   if (missing.length) {
-    l.warn(`${missing.length} control-ids aus dem Profil sind im Kernel-Katalog nicht gefunden: ${missing.slice(0,5).join(", ")}${missing.length>5?"…":""}`);
+    l.warn(`${missing.length}/${ids.length} Pool-Control-IDs nicht im Anwenderkatalog gefunden: ${missing.slice(0,5).join(", ")}${missing.length>5?"…":""}`);
   }
   if (controls.length === 0) {
-    throw new Error("keine Controls aus dem Profil im Katalog auflösbar");
+    throw new Error("keine Pool-Controls im G++ Anwenderkatalog auflösbar — ist der Katalog geladen?");
   }
+  l.ok(`${controls.length} Pool-Controls mit Prose aufgelöst`);
 
-  // 4. Test drive: sample Anforderungen, not controls
+  // 2. Test drive: sample Anforderungen
   const td = $("testdrive").checked;
   let anforderungen = state.baustein.requirements;
   if (anforderungen.length === 0) {
@@ -1750,10 +1767,10 @@ async function runStage2_C1_sentenceMapping() {
     $("td-banner").classList.remove("show");
   }
 
-  // 5. Prepare the controls block — same in every batch
+  // 3. Prepare the controls block — same in every batch (Titel + Statement-Prosa)
   const controlsBlock = controls.map(c => {
     const stm = (c.statement || "").replace(/\s+/g, " ").trim();
-    return `${c.id} — ${c.title}\n  (${c.modalverb || "?"}) ${stm.slice(0, 400)}`;
+    return `${c.id} — ${c.title}\n  (${c.modalverb || "?"}) ${stm.slice(0, 700)}`;
   }).join("\n\n");
 
   // 6. Batch the Anforderungen
@@ -1762,7 +1779,7 @@ async function runStage2_C1_sentenceMapping() {
   for (let i = 0; i < anforderungen.length; i += batchSize) {
     batches.push(anforderungen.slice(i, i + batchSize));
   }
-  l.info(`stage 2 (C.1) · ${anforderungen.length} Anforderungen in ${batches.length} Batches à ${batchSize} · ${controls.length} Controls per Batch`);
+  l.info(`stage 2 (${state.pipelineMode}) · ${anforderungen.length} Anforderungen in ${batches.length} Batches à ${batchSize} · ${controls.length} Controls per Batch`);
 
   // 7. Run pool — one call per batch; accumulate mappings
   state.sentenceMappings = [];
@@ -1816,7 +1833,7 @@ async function runStage2_C1_sentenceMapping() {
   });
 
   await runPool(tasks, concurrency, (d, t) => {
-    showProgress(`stage 2 (C.1) · sentence-mapping (${d}/${t} batches)`, d, t);
+    showProgress(`stage 2 (${state.pipelineMode}) · sentence-mapping (${d}/${t} batches)`, d, t);
   });
 
   // 8. Invert mappings: build one implReq slot per control with mapped sentences attached
@@ -1872,7 +1889,7 @@ async function runStage2_C1_sentenceMapping() {
   if (totalSent < totalPdfSent) {
     l.warn(`Modell hat ${totalSent} Sätze verarbeitet, im PDF waren ${totalPdfSent} (Differenz: ${totalPdfSent - totalSent} Sätze hat das Modell nicht zurückgeliefert)`);
   }
-  l.ok(`stage 2 (C.1) done · ${mappedSent}/${totalSent} Sätze gemappt · ${state.unmappedSentences.length} als Kontext · ${state.implReqs.filter(r => r.coverage !== "missing").length}/${state.implReqs.length} Controls erhalten ≥1 Satz`);
+  l.ok(`stage 2 (${state.pipelineMode}) done · ${mappedSent}/${totalSent} Sätze gemappt · ${state.unmappedSentences.length} als Kontext · ${state.implReqs.filter(r => r.coverage !== "missing").length}/${state.implReqs.length} Controls erhalten ≥1 Satz`);
 }
 
 async function runStage2_C2_deterministic() {
@@ -2103,11 +2120,8 @@ function renderStage2() {
 
 $("s2-filter").addEventListener("change", renderStage2);
 $("pi-pick").addEventListener("change", () => {
-  // Just persist; re-render stage 1 to show the override
-  if (state.matchedProfile) renderStage1();
-});
-$("match-threshold").addEventListener("input", () => {
-  if (state.matchedProfile) renderStage1();
+  // Re-render stage 1 to reflect the manual override
+  if (state.classification || $("pi-pick").value) renderStage1();
 });
 
 /* ════════════════════════════════════════════════════════════════════════
@@ -2127,38 +2141,59 @@ function assembleProfile() {
   const now = new Date().toISOString();
   const bId  = state.baustein?.id || "BSI-Baustein";
   const bTit = state.baustein?.title || "Baustein";
+  const cat  = state.classification?.zielobjekt_name;
+  const profileTitle = (bTit ? `${bId} ${bTit}` : bId)
+    + (state.pipelineMode === "ZIELOBJEKT" && cat ? ` → ${cat}` : state.pipelineMode === "PROZESS" ? " → Prozess" : "");
 
-  // component title: use baustein title (with id prefix)
-  const componentTitle = bTit ? `${bId} ${bTit}` : bId;
+  // Only controls that actually received ≥1 mapped sentence end up in the profile.
+  const matched = state.implReqs.filter(r => !r.pending && !r.error && r.coverage !== "missing");
+  const uniqueControls = [...new Set(matched.map(r => r.control_id))];
 
-  // Extract all control IDs from implementedRequirements
-  const controlIds = state.implReqs
-    .filter(r => !r.pending && !r.error)
-    .map(r => r.control_id);
-
-  // remove duplicates
-  const uniqueControls = [...new Set(controlIds)];
+  // OSCAL "alters": embed the verbatim Ed2023 PDF text at the matched control,
+  // so the migrated requirement source is traceable inside the profile itself.
+  const NS = "https://github.com/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools";
+  const alters = matched.map(r => {
+    const prose = (r.mapped_sentences || [])
+      .map(m => `[${m.anforderung_id}, Satz ${m.sentence_idx}] ${m.sentence_text}`)
+      .join("\n\n");
+    return {
+      "control-id": r.control_id,
+      "adds": [{
+        "position": "ending",
+        "props": [{ "name": "source-baustein", "ns": NS, "value": bId }],
+        "parts": [{
+          "id": `${r.control_id}_ed2023-quelle`,
+          "name": "ed2023-quelle",
+          "ns": NS,
+          "title": `Quelle: BSI IT-Grundschutz Ed2023 · ${bId}`,
+          "prose": prose || `(kein Satz aus ${bId} gemappt)`,
+        }],
+      }],
+    };
+  });
 
   const profile = {
     "profile": {
       "uuid": crypto.randomUUID(),
       "metadata": {
-        "title": componentTitle,
+        "title": profileTitle,
         "last-modified": now,
         "version": "0.1.0",
-        "oscal-version": "1.1.3"
+        "oscal-version": "1.1.3",
+        "props": [
+          { "name": "source-baustein", "ns": NS, "value": bId },
+          { "name": "mapping-mode", "ns": NS, "value": state.pipelineMode || "?" },
+          ...(state.classification?.zielobjekt_uuid ? [{ "name": "zielobjekt-uuid", "ns": NS, "value": state.classification.zielobjekt_uuid }] : []),
+        ],
       },
       "imports": [
         {
-          "href": "https://raw.githubusercontent.com/BSI-Bund/Stand-der-Technik-Bibliothek/refs/heads/main/Anwenderkataloge/Grundschutz%2B%2B/Grundschutz%2B%2B-catalog.json",
-          "include-controls": [
-            {
-              "with-ids": uniqueControls
-            }
-          ]
-        }
-      ]
-    }
+          "href": GPP_CATALOG_HREF,
+          "include-controls": [{ "with-ids": uniqueControls }],
+        },
+      ],
+      ...(alters.length ? { "modify": { "alters": alters } } : {}),
+    },
   };
 
   return profile;
@@ -2169,7 +2204,8 @@ function renderStage3() {
   card.classList.remove("hidden");
   $("s3-output").value = JSON.stringify(state.profileDef, null, 2);
   const n = state.profileDef?.["profile"]?.["imports"]?.[0]?.["include-controls"]?.[0]?.["with-ids"]?.length || 0;
-  $("s3-chip").textContent = `${state.pipelineMode} · ${n} impl-reqs`;
+  const a = state.profileDef?.["profile"]?.["modify"]?.["alters"]?.length || 0;
+  $("s3-chip").textContent = `${state.pipelineMode} · ${n} Controls · ${a} alters`;
   $("btn-download-cat").classList.toggle("hidden", state.pipelineMode !== "C2" || !state.customCatalog);
 }
 
@@ -2524,9 +2560,9 @@ function updateRunLabel() {
 
 async function run() {
   if (state.running) return;
-  if (!$("api-key").value.trim() && !$("pi-pick").value) { l.err("API-Key fehlt (oder manuell ein Profil wählen + Stage 1 überspringen ist auch noch nicht implementiert)"); return; }
+  if (!$("api-key").value.trim()) { l.err("API-Key fehlt"); return; }
   if (!state.baustein) { l.err("kein PDF geladen"); return; }
-  if (!state.catalogControls.length) { l.err("kein Katalog geladen"); return; }
+  if (!state.catalogControls.length) { l.err("kein G++ Anwenderkatalog geladen"); return; }
 
   state.running = true;
   state.cancel = false;
@@ -2539,29 +2575,35 @@ async function run() {
   try {
     const tAll = performance.now();
 
-    // Stage 1 — only if no manual override
-    if ($("pi-pick").value) {
-      l.info(`manual override · Profil "${$("pi-pick").value}" — Stage 1 übersprungen`);
-      state.matchedProfile = {
-        profile_filename: $("pi-pick").value,
+    // Stage 1 — classification (skipped if a category is manually picked)
+    const manual = $("pi-pick").value;
+    if (manual) {
+      const isProz = manual === "__prozess__";
+      const cat = isProz ? null : (state.categories.find(c => c.uuid === manual) || null);
+      l.info(`manual override · ${isProz ? "PROZESS" : (cat?.name || manual)} — Stage 1 übersprungen`);
+      state.classification = {
+        object_type: isProz ? "prozess" : "zielobjekt",
+        zielobjekt_name: cat?.name || null,
+        zielobjekt_uuid: isProz ? null : manual,
         confidence: 1.0,
         rationale: "Manuell ausgewählt durch Anwender.",
+        alternatives: [],
       };
       doneStage("s1");
       renderStage1();
     } else {
-      await runStage1ProfileMatch();
+      await runStage1Classify();
     }
     if (state.cancel) throw new Error("cancelled");
 
     await runStage2();
     if (state.cancel) throw new Error("cancelled");
 
-    if ($("maker-checker").checked && state.pipelineMode === "C1") {
+    if ($("maker-checker").checked && state.pipelineMode !== "C2") {
       await runChecker();
       if (state.cancel) throw new Error("cancelled");
     } else if ($("maker-checker").checked && state.pipelineMode === "C2") {
-      l.info("checker übersprungen — C.2 ist deterministisch");
+      l.info("checker übersprungen — C.2-Fallback ist deterministisch");
     }
 
     await runStage3();
@@ -2591,10 +2633,8 @@ $("btn-cancel").addEventListener("click", () => {
   l.warn("cancel requested — finishing in-flight calls");
 });
 $("btn-clear").addEventListener("click", () => {
-  state.matchedProfile = null;
-  state.matchedProfileJson = null;
-  state.matchedProfileFilename = null;
-  state.profileControlIds = [];
+  state.classification = null;
+  state.poolControlIds = [];
   state.pipelineMode = null;
   state.implReqs = [];
   state.sentenceMappings = [];
@@ -2619,16 +2659,18 @@ $("btn-clear").addEventListener("click", () => {
 loadPrefs();
 updateRunLabel();
 
-// Auto-load catalog + profile-index on startup
+// Auto-load G++ Anwenderkatalog + Zielobjektkategorien + Pools on startup
 window.addEventListener("load", () => {
   if ($("cat-url").value.trim()) {
-    l.info("auto-loading Kernel catalog…");
+    l.info("auto-loading G++ Anwenderkatalog…");
     $("btn-load-cat").click();
   }
   if ($("pi-url").value.trim()) {
-    l.info("auto-loading profile-index…");
+    l.info("auto-loading Zielobjektkategorien…");
     setTimeout(() => $("btn-load-pi").click(), 200);  // stagger to not collide
   }
+  l.info("auto-loading Control-Pools…");
+  setTimeout(loadPools, 400);
 });
 
 </script>

--- a/One-Page-Apps/Baustein_2_Profile.html
+++ b/One-Page-Apps/Baustein_2_Profile.html
@@ -317,9 +317,10 @@ body{
       <div>
         <div class="brand-name">Baustein_2_Profile</div>
       </div>
-      <span class="brand-sub">build 0.8.0 · LLM-Klassifikation → G++ Anwenderkatalog-Pool → Satz-Mapping → OSCAL-Profil mit alters · v4-gpp prompt</span>
+      <span class="brand-sub">build 0.8.1 · LLM-Klassifikation → G++-Pool (chunked, cached prefix) → Satz-Mapping → OSCAL-Profil mit alters · Token-Tracking · v5-chunked prompt</span>
     </div>
     <div class="meta-pills">
+      <span id="token-pill" class="pill" title="Token-Verbrauch (kumuliert pro Run)">Σ 0 tok · cache 0 (0%)</span>
       <span id="status-pill" class="pill">bereit</span>
       <span class="pill live">● Gemini 3</span>
     </div>
@@ -369,8 +370,8 @@ body{
           </div>
           <div class="field-row">
             <div class="field">
-              <label>Anf./Batch (Stage 2)</label>
-              <input id="anf-batch" type="number" min="1" max="20" value="5">
+              <label>Controls/Chunk (S2)</label>
+              <input id="ctrl-chunk" type="number" min="10" max="400" value="100">
             </div>
             <div class="field">
               <label>Chunk (Checker)</label>
@@ -605,10 +606,14 @@ body{
           <input type="checkbox" id="log-autoscroll" checked style="accent-color:var(--accent)">
           autoscroll
         </label>
+        <button class="btn sm ghost" id="btn-toggle-log">▤ text</button>
+        <button class="btn sm ghost" id="btn-copy-log">⌕ copy</button>
         <button class="btn sm ghost" id="btn-clear-log">clear</button>
       </div>
     </div>
     <div class="console-body" id="log-body"></div>
+    <textarea id="log-ta" class="hidden" readonly spellcheck="false"
+      style="flex:1;min-height:0;margin:0;border:0;border-radius:0;resize:none;background:var(--bg-deep);color:var(--text-secondary);font-family:'JetBrains Mono',monospace;font-size:10.5px;line-height:1.6;padding:8px 16px;outline:none"></textarea>
   </div>
 
 </div>
@@ -676,25 +681,20 @@ KARDINAL-REGEL — DER DEFAULT IST: ES GIBT EIN MAPPING.
 
 VORGEHEN PRO SATZ:
 1. Identifiziere die Haupt-Thematik(en) des Satzes.
-2. Scanne die GESAMTE G++-Control-Liste — nicht nur den Anfang oder die offensichtlichen Treffer. Der Pool ist bereits auf die richtige Zielobjektkategorie/Prozess eingegrenzt, also passt fast immer mindestens ein Control.
-3. Liste JEDEN Control, der inhaltlich Berührungspunkte hat (auch bei nur teilweiser Überlappung). Im Zweifel mappen statt verwerfen.
-4. Bei Mehrfach-Adressierung im Satz ("Es MUSS dokumentiert UND freigegeben werden") → mappe auf BEIDE Themen.
+2. Prüfe JEDEN Control in DIESEM Chunk auf inhaltliche Berührungspunkte (auch bei nur teilweiser Überlappung). Im Zweifel mappen statt verwerfen.
+3. Bei Mehrfach-Adressierung im Satz ("Es MUSS dokumentiert UND freigegeben werden") → mappe auf BEIDE Themen, sofern in diesem Chunk vorhanden.
 
-WANN GILT EIN SATZ ALS UNMAPPED (Ausnahme, selten):
-- Reine Einleitung ohne Modalverb ("Dieser Abschnitt regelt …")
-- Pure Erklärung/Hintergrund ("Kubernetes besteht aus Master und Worker Nodes")
-- Bloßer Verweis ohne eigenen Inhalt ("Siehe APP.4.5")
+WICHTIG — CHUNKING:
+- Du bekommst pro Request nur einen AUSSCHNITT (Chunk) des Control-Pools. Mappe jeden Satz NUR auf Controls aus DIESEM Chunk.
+- Gib NUR Mapping-Elemente für Sätze zurück, die in DIESEM Chunk mindestens ein passendes Control haben. Sätze ohne Treffer in diesem Chunk einfach WEGLASSEN — das spart Tokens und ist erwünscht, da die übrigen Controls in anderen Chunks stehen.
+- Erfinde NICHTS, um einen Treffer zu erzwingen.
 
 REGELN:
-- mapped_control_ids: nur IDs aus der unten gelieferten Liste. KEINE Halluzination, KEIN Erfinden von Control-IDs.
-- sentence_text: VERBATIM aus der Eingabe zurückgeben — Wort für Wort, kein Umformulieren.
-- rationale: ein Satz Deutsch — bei Mapping: was den Satz mit den Controls verbindet; bei unmapped: warum gar keine Verwandtschaft besteht.
-- Liefere EIN Mapping-Element PRO SATZ aus den unten gelisteten Anforderungen — keinen Satz weglassen.
+- mapped_control_ids: mindestens eine, nur IDs aus der unten gelieferten Control-Liste (diesem Chunk). KEINE Halluzination, KEIN Erfinden von Control-IDs.
+- sentence_text: VERBATIM aus der Eingabe zurückgeben — Wort für Wort, kein Umformulieren (dient nur der Zuordnung; anforderung_id + sentence_idx sind maßgeblich).
+- rationale: ein kurzer Satz Deutsch, was den Satz mit dem/den Control(s) verbindet.
 
 BAUSTEIN: {baustein_id} – {baustein_title}
-
-G++-CONTROLS (target-Pool, jeweils Titel + Statement-Prosa):
-{controls}
 
 ANFORDERUNGEN AUS DEM BAUSTEIN MIT EINZELSÄTZEN (zu verteilen):
 {anforderungen_with_sentences}
@@ -710,7 +710,11 @@ OUTPUT-JSON:
       "rationale": string
     }
   ]
-}`;
+}
+
+════════════════════════════════════════════════════════════
+G++-CONTROLS — NUR DIESER CHUNK (ID — Titel: Beschreibung):
+{controls}`;
 
 const DEFAULT_CHECK_PROMPT = `Du bist QS für BSI-Compliance-Mappings. Vor dir liegen Implementation-Statements, die ein erster AI-Pass (Maker) für Kernel-Controls erzeugt hat, gestützt auf einen Edition-2023-Baustein. Audit-Aufgabe: Bestätige, korrigiere oder verwirf jedes Statement.
 
@@ -777,6 +781,10 @@ const state = {
   categoriesByName: null,   // Map name(lower) → category
   zoControlsMap: null,      // Map zielobjekt-UUID → [control-id]
   ismsControlIds: [],       // [control-id] for the Prozess/ISMS pool
+  strippedById: null,       // Map control-id → {name, desc} from gpp_isms_stripped.md (cheap match context)
+
+  // token accounting (Gemini usageMetadata, accumulated per run)
+  tokens: { prompt: 0, cached: 0, candidates: 0, thoughts: 0, total: 0, calls: 0 },
 
   // pipeline outputs
   classification: null,     // { object_type, zielobjekt_name, zielobjekt_uuid, confidence, rationale, alternatives }
@@ -802,6 +810,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
    ════════════════════════════════════════════════════════════════════════ */
 
 const logBody = $("log-body");
+const logTA = $("log-ta");
 let logCount = 0;
 
 const l = {
@@ -812,9 +821,14 @@ const l = {
     div.innerHTML = `<span class="log-ts">${ts}</span><span class="log-lvl">${level}</span><span class="log-msg"></span>`;
     div.querySelector(".log-msg").textContent = msg;
     logBody.appendChild(div);
+    // mirror as plaintext into the selectable/copyable textarea
+    logTA.value += `${ts} ${level.toUpperCase().padEnd(5)} ${msg}\n`;
     logCount++;
     $("log-count").textContent = logCount;
-    if ($("log-autoscroll").checked) logBody.scrollTop = logBody.scrollHeight;
+    if ($("log-autoscroll").checked) {
+      logBody.scrollTop = logBody.scrollHeight;
+      logTA.scrollTop = logTA.scrollHeight;
+    }
   },
   info(m)  { this._add("info", m) },
   ok(m)    { this._add("ok", m) },
@@ -823,19 +837,29 @@ const l = {
   debug(m) { this._add("debug", m) },
 };
 
-l.info("init · build 0.7.1 · pdf → profile-match → impl-reqs → component");
+l.info("init · build 0.8.1 · pdf → klassifikation → pool-chunk-mapping → oscal-profil mit alters");
 
 $("btn-clear-log").addEventListener("click", () => {
   logBody.innerHTML = "";
+  logTA.value = "";
   logCount = 0;
   $("log-count").textContent = "0";
+});
+$("btn-toggle-log").addEventListener("click", () => {
+  const showTA = logBody.classList.toggle("hidden");
+  logTA.classList.toggle("hidden", !showTA);
+  $("btn-toggle-log").textContent = showTA ? "▤ pretty" : "▤ text";
+});
+$("btn-copy-log").addEventListener("click", async () => {
+  try { await navigator.clipboard.writeText(logTA.value); l.ok("Log in Zwischenablage"); }
+  catch (e) { l.err(`copy failed: ${e.message}`); }
 });
 
 /* ════════════════════════════════════════════════════════════════════════
    Persistence + prompt textareas
    ════════════════════════════════════════════════════════════════════════ */
 
-const PROMPT_VERSION = "v4-gpp";  // bumps when DEFAULTS change shape — invalidates user overrides
+const PROMPT_VERSION = "v5-chunked";  // bumps when DEFAULTS change shape — invalidates user overrides
 
 function loadPrefs() {
   // Migration: if stored prompt-version differs, clear stored prompt overrides so new defaults load
@@ -857,7 +881,7 @@ function loadPrefs() {
   $("concurrency").value     = localStorage.getItem("gpp.conc")      || "4";
   $("retries").value         = localStorage.getItem("gpp.retries")   || "2";
   $("chunk-size").value      = localStorage.getItem("gpp.chunk")     || "8";
-  $("anf-batch").value       = localStorage.getItem("gpp.anfbatch")  || "5";
+  $("ctrl-chunk").value      = localStorage.getItem("gpp.ctrlchunk") || "100";
   $("maker-checker").checked = localStorage.getItem("gpp.mc")        === "1";
   $("grounding").checked     = localStorage.getItem("gpp.ground")    === "1";
   $("testdrive").checked     = localStorage.getItem("gpp.td")        === "1";
@@ -880,7 +904,7 @@ bindPersist("thinking", "gpp.thinking");
 bindPersist("concurrency", "gpp.conc");
 bindPersist("retries", "gpp.retries");
 bindPersist("chunk-size", "gpp.chunk");
-bindPersist("anf-batch", "gpp.anfbatch");
+bindPersist("ctrl-chunk", "gpp.ctrlchunk");
 bindPersist("cat-url", "gpp.caturl");
 bindPersist("pi-url", "gpp.piurl");
 
@@ -1317,16 +1341,22 @@ async function loadPools() {
     const map = zoJson?.zielobjekt_controls_map ?? zoJson;
     state.zoControlsMap = new Map(Object.entries(map));
 
-    // gpp_isms_stripped.md → set of control IDs from the first table column
+    // gpp_isms_stripped.md → id + name + description per table row (cheap match context)
     const ismsText = await ismsRes.text();
     const ids = [];
+    const stripped = new Map();
     for (const line of ismsText.split("\n")) {
-      const m = line.match(/^\s*\|\s*([A-Z][A-Z0-9]*(?:\.\d+)+)\s*\|/);
-      if (m) ids.push(m[1]);
+      // | ID | name | description | UUID |
+      const m = line.match(/^\s*\|\s*([A-Z][A-Z0-9]*(?:\.\d+)+)\s*\|([^|]*)\|([^|]*)\|/);
+      if (!m) continue;
+      const id = m[1];
+      ids.push(id);
+      stripped.set(id, { name: m[2].trim(), desc: m[3].trim() });
     }
     state.ismsControlIds = ids;
-    $("pool-info").textContent = `${state.zoControlsMap.size} ZO-Pools · ${ids.length} ISMS-Controls`;
-    l.ok(`Pools geladen in ${Math.round(performance.now()-t0)}ms · ${state.zoControlsMap.size} ZO-Pools · ${ids.length} ISMS-Controls`);
+    state.strippedById = stripped;
+    $("pool-info").textContent = `${state.zoControlsMap.size} ZO-Pools · ${ids.length} ISMS-Controls (stripped)`;
+    l.ok(`Pools geladen in ${Math.round(performance.now()-t0)}ms · ${state.zoControlsMap.size} ZO-Pools · ${ids.length} ISMS-Controls (mit stripped-Beschreibung)`);
   } catch (e) {
     l.err(`Pool-Load fehlgeschlagen: ${e.message}`);
     $("pool-info").textContent = `Pools Fehler: ${e.message}`;
@@ -1401,9 +1431,37 @@ async function llmOnce(prompt, schema) {
     throw new Error(detail);
   }
   const data = await res.json();
+  addTokens(data?.usageMetadata);
   const text = (data?.candidates?.[0]?.content?.parts || []).map(p => p.text || "").join("\n");
   if (!text) throw new Error("leere Modellantwort");
   return text;
+}
+
+/* ── Token accounting (Gemini usageMetadata) ─────────────────────────────── */
+function resetTokens() {
+  state.tokens = { prompt: 0, cached: 0, candidates: 0, thoughts: 0, total: 0, calls: 0 };
+  updateTokenPill();
+}
+function addTokens(u) {
+  if (!u) return;
+  const t = state.tokens;
+  t.prompt     += u.promptTokenCount        || 0;
+  t.cached     += u.cachedContentTokenCount || 0;
+  t.candidates += u.candidatesTokenCount    || 0;
+  t.thoughts   += u.thoughtsTokenCount      || 0;
+  t.total      += u.totalTokenCount         || 0;
+  t.calls      += 1;
+  updateTokenPill();
+}
+const fmtTok = n => n >= 1000 ? (n / 1000).toFixed(n >= 10000 ? 0 : 1) + "k" : String(n);
+function updateTokenPill() {
+  const t = state.tokens;
+  const pill = $("token-pill");
+  if (!pill) return;
+  const pct = t.prompt > 0 ? Math.round((t.cached / t.prompt) * 100) : 0;
+  pill.textContent = `Σ ${fmtTok(t.total)} tok · cache ${fmtTok(t.cached)} (${pct}%)`;
+  pill.title = `${t.calls} calls · prompt ${t.prompt} (davon cached ${t.cached}) · output ${t.candidates} · thoughts ${t.thoughts} · total ${t.total}`;
+  pill.classList.toggle("live", t.cached > 0);
 }
 
 async function llm(prompt, label, schema) {
@@ -1767,83 +1825,82 @@ async function runStage2_SentenceMapping() {
     $("td-banner").classList.remove("show");
   }
 
-  // 3. Prepare the controls block — same in every batch (Titel + Statement-Prosa)
-  const controlsBlock = controls.map(c => {
-    const stm = (c.statement || "").replace(/\s+/g, " ").trim();
-    return `${c.id} — ${c.title}\n  (${c.modalverb || "?"}) ${stm.slice(0, 700)}`;
+  // 3. Constant prefix (cache-friendly): ALL Anforderungen + their sentences are
+  //    sent in every request unchanged — only the control-chunk at the end varies.
+  const anfBlock = anforderungen.map(a => {
+    const sentLines = (a.sentences || []).map(s => `  Satz ${s.idx}: ${s.text}`).join("\n");
+    return `${a.id} — ${a.name || "(ohne Name)"}\n${sentLines || "  (keine Sätze erkannt)"}`;
   }).join("\n\n");
 
-  // 6. Batch the Anforderungen
-  const batchSize = Math.max(1, parseInt($("anf-batch").value) || 5);
-  const batches = [];
-  for (let i = 0; i < anforderungen.length; i += batchSize) {
-    batches.push(anforderungen.slice(i, i + batchSize));
+  // Control context line: prefer the cheap stripped description, else catalog statement.
+  const ctxLine = c => {
+    const st = state.strippedById?.get(c.id);
+    const text = (st && st.desc) ? st.desc : (c.statement || "").replace(/\s+/g, " ").trim();
+    return `${c.id} — ${c.title}: ${text.slice(0, 500)}`;
+  };
+
+  // 4. Chunk the control pool (variable suffix). ~chunkSize controls per request.
+  const chunkSize = Math.max(10, parseInt($("ctrl-chunk").value) || 100);
+  const chunks = [];
+  for (let i = 0; i < controls.length; i += chunkSize) chunks.push(controls.slice(i, i + chunkSize));
+  l.info(`stage 2 (${state.pipelineMode}) · ${controls.length} Controls in ${chunks.length} Chunks à ${chunkSize} · ${anforderungen.length} Anforderungen (konstanter Prefix → Prompt-Caching)`);
+
+  // 5. Pre-seed every PDF sentence so each is accounted even if never returned.
+  //    A sentence's mapped controls are the UNION across all chunk responses.
+  const sentMap = new Map();  // `${anfId}#${idx}` → {…, ids:Set}
+  for (const a of anforderungen) for (const s of (a.sentences || [])) {
+    sentMap.set(`${a.id}#${s.idx}`, {
+      anforderung_id: a.id, anforderung_name: a.name, anforderung_modalverb: a.modalverb,
+      sentence_idx: s.idx, sentence_text: s.text, ids: new Set(), rationale: "",
+    });
   }
-  l.info(`stage 2 (${state.pipelineMode}) · ${anforderungen.length} Anforderungen in ${batches.length} Batches à ${batchSize} · ${controls.length} Controls per Batch`);
 
-  // 7. Run pool — one call per batch; accumulate mappings
-  state.sentenceMappings = [];
+  // 6. Run pool — one call per control-chunk; merge mappings into sentMap.
   const concurrency = Math.max(1, parseInt($("concurrency").value) || 4);
-  const tasks = batches.map((batch, idx) => async () => {
-    const anfBlock = batch.map(a => {
-      const sentLines = (a.sentences || []).map(s => `  Satz ${s.idx}: ${s.text}`).join("\n");
-      return `${a.id} — ${a.name || "(ohne Name)"}\n${sentLines || "  (keine Sätze erkannt)"}`;
-    }).join("\n\n");
-
+  const tasks = chunks.map((chunk, idx) => async () => {
     const prompt = buildPrompt("s2", {
       baustein_id: state.baustein.id || "?",
       baustein_title: state.baustein.title || "?",
-      controls: controlsBlock,
-      anforderungen_with_sentences: anfBlock,
+      anforderungen_with_sentences: anfBlock,                 // constant prefix
+      controls: chunk.map(ctxLine).join("\n\n"),              // variable suffix
     });
 
     try {
-      const text = await llm(prompt, `s2 batch ${idx+1}/${batches.length} (${batch.length} Anf.)`, $("grounding").checked ? null : SCHEMA_S2);
+      const text = await llm(prompt, `s2 chunk ${idx+1}/${chunks.length} (${chunk.length} Controls)`, $("grounding").checked ? null : SCHEMA_S2);
       const parsed = extractJson(text);
-      const mappings = parsed?.mappings || [];
-
-      // Validate: control-ids must be from the profile; anforderung-id+sentence_idx must exist
-      const validControlIds = new Set(controls.map(c => c.id));
-      const anfById = new Map(batch.map(a => [a.id, a]));
-      for (const m of mappings) {
-        const anf = anfById.get(m.anforderung_id);
-        if (!anf) { l.warn(`batch ${idx+1}: Modell mappt unbekannte Anforderung ${m.anforderung_id} — ignoriert`); continue; }
-        const sentObj = (anf.sentences || []).find(s => s.idx === m.sentence_idx);
-        if (!sentObj) {
-          l.warn(`batch ${idx+1}: ${m.anforderung_id} Satz ${m.sentence_idx} existiert nicht (Anf. hat ${anf.sentences?.length || 0} Sätze) — ignoriert`);
-          continue;
-        }
+      const validControlIds = new Set(chunk.map(c => c.id));
+      for (const m of (parsed?.mappings || [])) {
+        const slot = sentMap.get(`${m.anforderung_id}#${m.sentence_idx}`);
+        if (!slot) continue;  // unknown sentence — silently skip (chunk noise)
         const validIds = (m.mapped_control_ids || []).filter(id => validControlIds.has(id));
-        const halluc = (m.mapped_control_ids || []).filter(id => !validControlIds.has(id));
-        if (halluc.length) l.warn(`batch ${idx+1}: ${m.anforderung_id}/s${m.sentence_idx}: ${halluc.length} unbekannte Control-ID(s) entfernt: ${halluc.join(", ")}`);
-
-        state.sentenceMappings.push({
-          anforderung_id: m.anforderung_id,
-          anforderung_name: anf.name,
-          anforderung_modalverb: anf.modalverb,
-          sentence_idx: m.sentence_idx,
-          sentence_text: sentObj.text,  // use the verbatim PDF sentence, not what the model echoed
-          mapped_control_ids: validIds,
-          rationale: m.rationale || "",
-        });
+        for (const id of validIds) slot.ids.add(id);
+        if (validIds.length && !slot.rationale) slot.rationale = m.rationale || "";
       }
     } catch (e) {
-      l.err(`batch ${idx+1} failed: ${e.message}`);
+      l.err(`chunk ${idx+1} failed: ${e.message}`);
     }
   });
 
   await runPool(tasks, concurrency, (d, t) => {
-    showProgress(`stage 2 (${state.pipelineMode}) · sentence-mapping (${d}/${t} batches)`, d, t);
+    showProgress(`stage 2 (${state.pipelineMode}) · chunk-mapping (${d}/${t} Chunks)`, d, t);
   });
 
+  // 7. Finalize sentence mappings (merged, one entry per PDF sentence).
+  state.sentenceMappings = [...sentMap.values()].map(v => ({
+    anforderung_id: v.anforderung_id,
+    anforderung_name: v.anforderung_name,
+    anforderung_modalverb: v.anforderung_modalverb,
+    sentence_idx: v.sentence_idx,
+    sentence_text: v.sentence_text,
+    mapped_control_ids: [...v.ids],
+    rationale: v.rationale,
+  }));
+
   // 8. Invert mappings: build one implReq slot per control with mapped sentences attached
-  const sentencesByControl = new Map();           // controlId → [{anforderung_id, name, modalverb, sentence_idx, sentence_text, rationale}]
-  const unmappedSentences = [];                   // sentences with empty mapped_control_ids
+  const sentencesByControl = new Map();
+  const unmappedSentences = [];
   for (const m of state.sentenceMappings) {
-    if (m.mapped_control_ids.length === 0) {
-      unmappedSentences.push(m);
-      continue;
-    }
+    if (m.mapped_control_ids.length === 0) { unmappedSentences.push(m); continue; }
     for (const cid of m.mapped_control_ids) {
       if (!sentencesByControl.has(cid)) sentencesByControl.set(cid, []);
       sentencesByControl.get(cid).push(m);
@@ -1851,7 +1908,7 @@ async function runStage2_SentenceMapping() {
   }
   state.unmappedSentences = unmappedSentences;
   if (unmappedSentences.length) {
-    l.info(`${unmappedSentences.length} Sätze wurden als Kontext klassifiziert (kein Control-Mapping)`);
+    l.info(`${unmappedSentences.length} Sätze ohne Control-Treffer (Kontext / kein passendes Control im Pool)`);
   }
 
   // 9. Build implReqs from controls, attach mapped sentences
@@ -1885,11 +1942,7 @@ async function runStage2_SentenceMapping() {
   // Log sentence-side accounting so the user sees recall at the sentence level
   const totalSent = state.sentenceMappings.length;
   const mappedSent = totalSent - state.unmappedSentences.length;
-  const totalPdfSent = anforderungen.reduce((s, a) => s + (a.sentences?.length || 0), 0);
-  if (totalSent < totalPdfSent) {
-    l.warn(`Modell hat ${totalSent} Sätze verarbeitet, im PDF waren ${totalPdfSent} (Differenz: ${totalPdfSent - totalSent} Sätze hat das Modell nicht zurückgeliefert)`);
-  }
-  l.ok(`stage 2 (${state.pipelineMode}) done · ${mappedSent}/${totalSent} Sätze gemappt · ${state.unmappedSentences.length} als Kontext · ${state.implReqs.filter(r => r.coverage !== "missing").length}/${state.implReqs.length} Controls erhalten ≥1 Satz`);
+  l.ok(`stage 2 (${state.pipelineMode}) done · ${mappedSent}/${totalSent} PDF-Sätze gemappt · ${state.unmappedSentences.length} ohne Treffer · ${state.implReqs.filter(r => r.coverage !== "missing").length}/${state.implReqs.length} Controls erhalten ≥1 Satz`);
 }
 
 async function runStage2_C2_deterministic() {
@@ -2566,6 +2619,7 @@ async function run() {
 
   state.running = true;
   state.cancel = false;
+  resetTokens();
   $("btn-run").disabled = true;
   $("btn-cancel").classList.remove("hidden");
   resetStages();
@@ -2608,7 +2662,7 @@ async function run() {
 
     await runStage3();
     showProgress("done", 1, 1);
-    l.ok(`pipeline done in ${Math.round((performance.now()-tAll)/100)/10}s · mode=${state.pipelineMode}`);
+    l.ok(`pipeline done in ${Math.round((performance.now()-tAll)/100)/10}s · mode=${state.pipelineMode} · ${state.tokens.calls} calls · ${state.tokens.total} tok (cached ${state.tokens.cached})`);
     $("status-pill").textContent = "fertig";
   } catch (e) {
     l.err(`pipeline aborted: ${e.message}`);

--- a/One-Page-Apps/pruefung_ap_ar.html
+++ b/One-Page-Apps/pruefung_ap_ar.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OSCAL Assessment Plan & Results Generator v9</title>
+    <title>OSCAL Assessment Plan & Results Generator v9 (build 9.1 — local:// Defs ladbar)</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','sans-serif']}}}}</script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/15.0.0/marked.min.js"></script>
@@ -66,6 +66,7 @@
         <div class="space-y-1.5">
             <div id="dz-ssp" class="dz border border-dashed border-slate-600 rounded p-2 text-center cursor-pointer hover:border-emerald-500 bg-slate-900/40 text-[10px]" data-type="ssp">📋 SSP laden<input type="file" accept=".json" class="hidden fip" data-type="ssp"></div>
             <div id="dz-state" class="dz border border-dashed border-slate-600 rounded p-2 text-center cursor-pointer hover:border-purple-500 bg-slate-900/40 text-[10px]" data-type="state">💾 Session laden<input type="file" accept=".json" class="hidden fip" data-type="state"></div>
+            <div id="dz-defs" class="dz border border-dashed border-slate-600 rounded p-2 text-center cursor-pointer hover:border-cyan-500 bg-slate-900/40 text-[10px]" data-type="defs">📁 Profile/Defs laden<span class="block text-[8px] text-slate-500">für local:// Referenzen — mehrere möglich</span><input type="file" accept=".json" multiple class="hidden fip" data-type="defs"></div>
         </div>
         <!-- AI -->
         <div class="border border-slate-700 rounded overflow-hidden">
@@ -175,6 +176,7 @@ const S={
     compMeta:new Map(), compGroups:new Map(), allCids:new Set(),
     excluded:new Set(), methods:new Map(), findings:new Map(),
     aiCache:new Map(), // cid -> {explain:'(markdown)'}
+    localDefs:new Map(), // filename -> parsed profile JSON (für local:// Referenzen)
     meta:{title:'',version:'1.0.0',desc:''},
     assessor:{name:'',type:'organization',email:''},
     terms:{roe:'',disclosures:'',methodology:''},
@@ -202,8 +204,8 @@ document.addEventListener('DOMContentLoaded',()=>{
         dz.addEventListener('click',()=>fi.click());
         dz.addEventListener('dragover',e=>{e.preventDefault();dz.classList.add('drag-over')});
         dz.addEventListener('dragleave',()=>dz.classList.remove('drag-over'));
-        dz.addEventListener('drop',e=>{e.preventDefault();dz.classList.remove('drag-over');if(e.dataTransfer.files.length)loadFile(e.dataTransfer.files[0],ty)});
-        fi.addEventListener('change',e=>{if(e.target.files.length)loadFile(e.target.files[0],ty)});
+        dz.addEventListener('drop',e=>{e.preventDefault();dz.classList.remove('drag-over');const fs=e.dataTransfer.files;if(!fs.length)return;ty==='defs'?loadDefFiles(fs):loadFile(fs[0],ty)});
+        fi.addEventListener('change',e=>{const fs=e.target.files;if(!fs.length)return;ty==='defs'?loadDefFiles(fs):loadFile(fs[0],ty);e.target.value=''});
     });
     loadAICfg();
     loadCatalog();
@@ -279,6 +281,69 @@ function loadFile(file,type){
         }catch(err){alert('Fehler: '+err.message)}
     };
     r.readAsText(file);
+}
+
+// Lädt eine oder mehrere Profil-/Definitions-Dateien für local://-Referenzen.
+// Gespeichert nach Dateiname; danach werden offene Component-Defs neu aufgelöst.
+function loadDefFiles(files){
+    let pending=files.length,loaded=0,errs=[];
+    const done=()=>{
+        if(pending)return;
+        if(errs.length)alert('Einige Dateien nicht geladen:\n'+errs.join('\n'));
+        if(S.ssp){loadCompDefs()} // erneut auflösen — local:// greift jetzt auf S.localDefs zu
+        else{const cs=document.getElementById('comp-status');cs.classList.remove('hidden');cs.style.display='flex';cs.className="px-3 py-1 rounded-lg text-xs font-semibold bg-cyan-900/50 text-cyan-300 border border-cyan-700 flex items-center";cs.innerHTML=`<span class="w-2 h-2 rounded-full bg-cyan-500 mr-2"></span>${loaded} Profil(e) bereit — jetzt SSP laden`}
+    };
+    [...files].forEach(file=>{
+        if(!file.name.endsWith('.json')){errs.push(file.name+' (kein JSON)');pending--;done();return}
+        const r=new FileReader();
+        r.onload=e=>{try{S.localDefs.set(file.name,JSON.parse(e.target.result.replace(/^﻿/,'')));loaded++}catch(err){errs.push(file.name+': '+err.message)}pending--;done()};
+        r.onerror=()=>{errs.push(file.name);pending--;done()};
+        r.readAsText(file);
+    });
+}
+
+// Wandelt eine local://-Referenz in einen Dateinamen um (sonst null).
+function localName(u){return /^local:\/\//i.test(u)?u.replace(/^local:\/\//i,'').split(/[\\/]/).pop():null}
+
+// Liefert das geparste Profil zu einer defUrl: local:// → erst aus geladenen
+// Dateien (S.localDefs), sonst relativer Fetch (nur über http-Server); http(s) → CORS-Fetch.
+async function fetchDef(u){
+    const ln=localName(u);
+    if(ln!=null){
+        if(S.localDefs.has(ln))return S.localDefs.get(ln);
+        if(S.localDefs.has(u.replace(/^local:\/\//i,'')))return S.localDefs.get(u.replace(/^local:\/\//i,''));
+        let r;
+        try{r=await fetch(ln,{cache:'no-cache'})}
+        catch(e){throw new Error(`"${ln}" nicht gefunden — bitte über "📁 Profile/Defs laden" wählen (oder Seite per Webserver öffnen)`)}
+        if(!r.ok)throw new Error(`"${ln}" nicht gefunden (HTTP ${r.status}) — bitte über "📁 Profile/Defs laden" wählen`);
+        return JSON.parse((await r.text()).replace(/^﻿/,''));
+    }
+    const r=await fetch(u,{mode:'cors',cache:'no-cache'});
+    if(!r.ok)throw new Error(`HTTP ${r.status} ${r.statusText}`);
+    return JSON.parse((await r.text()).replace(/^﻿/,''));
+}
+
+// Wendet ein geparstes Profil auf eine Komponente an; gibt Anzahl neuer Controls zurück.
+function applyDefData(uuid,d){
+    const grp=S.compGroups.get(uuid)||new Map();let a=0;
+    const {ids,stmtByCtrl}=parseProfileEntry(d);
+    ids.forEach(cid=>{
+        if(!cid)return;
+        const ci=catInfo(cid);
+        const stmts=stmtByCtrl.get(cid)||[];
+        const defDesc=(stmts[0]&&stmts[0].prose)||ci.prose||'';
+        if(!grp.has(cid)){
+            grp.set(cid,{status:'nur-komponente',user:'',date:'',desc:'',stmtId:'',fromDef:true,defDesc:defDesc,defProps:[],statements:stmts});
+            a++;
+        } else {
+            const existing=grp.get(cid);
+            if((!existing.statements||!existing.statements.length)&&stmts.length)existing.statements=stmts;
+            if(!existing.defDesc)existing.defDesc=defDesc;
+        }
+        if(!S.allCids.has(cid)){S.allCids.add(cid);S.methods.set(cid,new Set(['EXAMINE']));S.findings.set(cid,{status:'',observation:'',risk:'',remarks:''})}
+    });
+    S.compGroups.set(uuid,grp);const m=S.compMeta.get(uuid);if(m){m.defLoaded=true;m.defN=grp.size}
+    return a;
 }
 
 // ============================================================
@@ -372,36 +437,17 @@ async function loadCompDefs(){
     for(const it of toLoad){
         cs.innerHTML=`<span class="loader-sm mr-2"></span>${esc(it.title)} (${done+1}/${toLoad.length})`;
         try{
-            const r=await fetch(it.url,{mode:'cors',cache:'no-cache'});
-            if(!r.ok)throw new Error(`HTTP ${r.status} ${r.statusText}`);
-            const txt=await r.text();
+            const txt=JSON.stringify(await fetchDef(it.url));
             let d;try{d=JSON.parse(txt.replace(/^\uFEFF/,''))}catch(pe){throw new Error('Kein gültiges JSON: '+pe.message)}
-            const grp=S.compGroups.get(it.uuid)||new Map();let a=0;
-            const {ids,stmtByCtrl}=parseProfileEntry(d);
-            ids.forEach(cid=>{
-                if(!cid)return;
-                const ci=catInfo(cid);
-                const stmts=stmtByCtrl.get(cid)||[];
-                const defDesc=(stmts[0]&&stmts[0].prose)||ci.prose||'';
-                if(!grp.has(cid)){
-                    grp.set(cid,{status:'nur-komponente',user:'',date:'',desc:'',stmtId:'',fromDef:true,
-                        defDesc:defDesc,defProps:[],statements:stmts});
-                    a++;
-                } else {
-                    const existing=grp.get(cid);
-                    if((!existing.statements||!existing.statements.length)&&stmts.length)existing.statements=stmts;
-                    if(!existing.defDesc)existing.defDesc=defDesc;
-                }
-                if(!S.allCids.has(cid)){S.allCids.add(cid);S.methods.set(cid,new Set(['EXAMINE']));S.findings.set(cid,{status:'',observation:'',risk:'',remarks:''})}
-            });
-            S.compGroups.set(it.uuid,grp);const m=S.compMeta.get(it.uuid);m.defLoaded=true;m.defN=grp.size;newN+=a;
+            newN+=applyDefData(it.uuid,d);
         }catch(e){
             console.error(`Fehler bei ${it.title}:`,e);
             fails.push({title:it.title,err:e.message,url:it.url,uuid:it.uuid});
         }done++}
     if(fails.length){
         cs.className="px-3 py-1 rounded-lg text-xs font-semibold bg-amber-900/50 text-amber-300 border border-amber-700 flex items-center";
-        cs.innerHTML=`<span class="w-2 h-2 rounded-full bg-amber-500 mr-2"></span>${done-fails.length}/${done} Defs geladen, +${newN} Controls — <button onclick="retryFailedDefs()" class="ml-2 underline text-amber-200 hover:text-white font-bold">⟳ ${fails.length} fehlgeschlagene neu laden</button>`;
+        const hasLocal=fails.some(f=>/^local:\/\//i.test(f.url));
+        cs.innerHTML=`<span class="w-2 h-2 rounded-full bg-amber-500 mr-2"></span>${done-fails.length}/${done} Defs geladen, +${newN} Controls — <button onclick="retryFailedDefs()" class="ml-2 underline text-amber-200 hover:text-white font-bold">⟳ ${fails.length} fehlgeschlagene neu laden</button>${hasLocal?' &middot; <span class="text-amber-200">local:// Profile per „📁 Profile/Defs laden" wählen</span>':''}`;
         S._failedDefs=fails;
     }else{
         cs.className="px-3 py-1 rounded-lg text-xs font-semibold bg-emerald-900/50 text-emerald-400 border border-emerald-700 flex items-center";
@@ -417,21 +463,9 @@ window.retryFailedDefs=async()=>{
     for(const it of fails){
         cs.innerHTML=`<span class="loader-sm mr-2"></span>Retry: ${esc(it.title)} (${retried+1}/${fails.length})`;
         try{
-            const r=await fetch(it.url,{mode:'cors',cache:'reload'});
-            if(!r.ok)throw new Error(`HTTP ${r.status}`);
-            const d=JSON.parse((await r.text()).replace(/^\uFEFF/,''));
-            const grp=S.compGroups.get(it.uuid)||new Map();let a=0;
-            const {ids,stmtByCtrl}=parseProfileEntry(d);
-            ids.forEach(cid=>{
-                if(!cid)return;
-                const ci=catInfo(cid);
-                const stmts=stmtByCtrl.get(cid)||[];
-                const defDesc=(stmts[0]&&stmts[0].prose)||ci.prose||'';
-                if(!grp.has(cid)){grp.set(cid,{status:'nur-komponente',user:'',date:'',desc:'',stmtId:'',fromDef:true,defDesc:defDesc,defProps:[],statements:stmts});a++}
-                if(!S.allCids.has(cid)){S.allCids.add(cid);S.methods.set(cid,new Set(['EXAMINE']));S.findings.set(cid,{status:'',observation:'',risk:'',remarks:''})}
-            });
-            S.compGroups.set(it.uuid,grp);const m=S.compMeta.get(it.uuid);m.defLoaded=true;m.defN=grp.size;newN+=a;
-        }catch(e){stillFailing.push(it)}retried++}
+            const d=await fetchDef(it.url);
+            newN+=applyDefData(it.uuid,d);
+        }catch(e){stillFailing.push({...it,err:e.message})}retried++}
     S._failedDefs=stillFailing;
     if(stillFailing.length){
         cs.innerHTML=`<span class="w-2 h-2 rounded-full bg-red-500 mr-2"></span>${stillFailing.length} Defs nicht ladbar: ${stillFailing.map(f=>'<span class="text-red-300">'+esc(f.title)+' ('+esc(f.err)+')</span>').join(', ')}`;

--- a/One-Page-Apps/pruefung_ap_ar.html
+++ b/One-Page-Apps/pruefung_ap_ar.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OSCAL Assessment Plan & Results Generator v9 (build 9.1 — local:// Defs ladbar)</title>
+    <title>OSCAL Assessment Plan & Results Generator v9 (build 9.2 — local:// Defs ladbar, SSP-Risikoanalyse)</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','sans-serif']}}}}</script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/15.0.0/marked.min.js"></script>
@@ -178,6 +178,7 @@ const S={
     aiCache:new Map(), // cid -> {explain:'(markdown)'}
     localDefs:new Map(), // filename -> parsed profile JSON (für local:// Referenzen)
     meta:{title:'',version:'1.0.0',desc:''},
+    sspRisks:[], // detaillierte Risiken aus SSP back-matter (risk-analysis.json)
     assessor:{name:'',type:'organization',email:''},
     terms:{roe:'',disclosures:'',methodology:''},
     tasks:[],dateStart:'',dateEnd:'',setParams:[]
@@ -236,6 +237,30 @@ async function loadCatalog(){
 }
 
 function catInfo(cid){return S.catalog.get(cid)||{title:'',prose:''}}
+
+// UTF-8-sicheres Base64-Decoding (atob liefert latin1) — wie in ssp_ausfuellen.
+function base64DecodeUnicode(str){
+    try{return new TextDecoder().decode(Uint8Array.from(atob(str),c=>c.charCodeAt(0)))}
+    catch(e){return null}
+}
+
+// Liest die detaillierte Risikoanalyse aus der SSP back-matter
+// (resource → attachment base64, filename "risk-analysis.json" bzw. decodiertes {risks:[...]}).
+function extractSSPRisks(ssp){
+    const out=[];
+    (ssp['back-matter']?.resources||[]).forEach(r=>{
+        (r.attachments||[]).forEach(att=>{
+            if(!att?.base64?.value)return;
+            const isRisk=att.base64.filename==='risk-analysis.json'||(att['media-type']||'').includes('json');
+            if(!isRisk)return;
+            try{
+                const json=JSON.parse(base64DecodeUnicode(att.base64.value)||'null');
+                if(json&&Array.isArray(json.risks))out.push(...json.risks);
+            }catch(e){}
+        });
+    });
+    return out;
+}
 
 // Parst ein OSCAL-Profil (das alte Format war eine component-definition).
 // Control-IDs stammen aus imports[].include-controls[].with-ids.
@@ -349,11 +374,11 @@ function applyDefData(uuid,d){
 // ============================================================
 // SESSION
 // ============================================================
-function ser(){return JSON.stringify({_v:9,sspFilename:S.sspFilename,meta:S.meta,assessor:S.assessor,terms:S.terms,tasks:S.tasks,dateStart:S.dateStart,dateEnd:S.dateEnd,excluded:[...S.excluded],methods:[...S.methods.entries()].map(([k,v])=>[k,[...v]]),findings:[...S.findings.entries()],aiCache:[...S.aiCache.entries()],compGroups:[...S.compGroups.entries()].map(([k,m])=>[k,[...m.entries()]]),compMeta:[...S.compMeta.entries()],allCids:[...S.allCids]})}
+function ser(){return JSON.stringify({_v:9,sspFilename:S.sspFilename,meta:S.meta,sspRisks:S.sspRisks,assessor:S.assessor,terms:S.terms,tasks:S.tasks,dateStart:S.dateStart,dateEnd:S.dateEnd,excluded:[...S.excluded],methods:[...S.methods.entries()].map(([k,v])=>[k,[...v]]),findings:[...S.findings.entries()],aiCache:[...S.aiCache.entries()],compGroups:[...S.compGroups.entries()].map(([k,m])=>[k,[...m.entries()]]),compMeta:[...S.compMeta.entries()],allCids:[...S.allCids]})}
 
 function restoreSession(d){
     if(!d._v||d._v<6)return alert('Session-Format zu alt oder inkompatibel (v9 benötigt).');
-    S.sspFilename=d.sspFilename||'';S.meta=d.meta||{title:'',version:'1.0.0',desc:''};S.assessor=d.assessor||{name:'',type:'organization',email:''};
+    S.sspFilename=d.sspFilename||'';S.meta=d.meta||{title:'',version:'1.0.0',desc:''};S.sspRisks=d.sspRisks||[];S.assessor=d.assessor||{name:'',type:'organization',email:''};
     S.terms=d.terms||{roe:'',disclosures:'',methodology:''};S.tasks=d.tasks||[];S.dateStart=d.dateStart||'';S.dateEnd=d.dateEnd||'';
     S.excluded=new Set(d.excluded||[]);S.methods=new Map((d.methods||[]).map(([k,v])=>[k,new Set(v)]));
     S.findings=new Map(d.findings||[]);S.aiCache=new Map(d.aiCache||[]);
@@ -394,7 +419,9 @@ async function initSSP(){
         })});
     });
 
-    setSt('ssp-status',true,`SSP: ${sn} — ${S.allCids.size} Controls`);showUI();await loadCompDefs();
+    S.sspRisks=extractSSPRisks(ssp);
+    const riskTxt=S.sspRisks.length?`, ${S.sspRisks.length} Risiken`:'';
+    setSt('ssp-status',true,`SSP: ${sn} — ${S.allCids.size} Controls${riskTxt}`);showUI();await loadCompDefs();
 }
 
 function ensureGrp(u){if(!S.compGroups.has(u))S.compGroups.set(u,new Map());return S.compGroups.get(u)}
@@ -866,7 +893,28 @@ function exportAR(){
             fin.push(fd);
         }
     });
-    
+
+    // Detaillierte Risiken aus der SSP-Risikoanalyse (back-matter) als OSCAL-Risks übernehmen.
+    const NS="http://bsi.bund.de/ns/grundschutz";
+    S.sspRisks.forEach(r=>{
+        const props=[];
+        if(r.likelihood)props.push({name:"likelihood",ns:NS,value:r.likelihood});
+        if(r.impact)props.push({name:"impact",ns:NS,value:r.impact});
+        const oscalRisk={
+            uuid:r.uuid||crypto.randomUUID(),
+            title:r.title||'Risiko',
+            description:r.description||'',
+            statement:r.threat||r.description||r.title||'Risiko aus SSP-Risikoanalyse',
+            status:"open"
+        };
+        if(props.length)oscalRisk.props=props;
+        const notes=[];
+        if(r.targetComponent)notes.push('Betroffene Komponente: '+(S.compMeta.get(r.targetComponent)?.title||r.targetComponent));
+        if(Array.isArray(r.mitigatingControls)&&r.mitigatingControls.length)notes.push('Mitigierende Controls: '+r.mitigatingControls.map(m=>m&&m.id).filter(Boolean).join(', '));
+        if(notes.length)oscalRisk.remarks=notes.join('\n');
+        rsk.push(oscalRisk);
+    });
+
     if(!fin.length)return alert('Keine bewerteten Controls.');
     const ar={"assessment-results":{uuid:crypto.randomUUID(),metadata:{title:`${sn().replace(/_/g,' ')} - Assessment Results`,version:S.meta.version||'1.0.0',"last-modified":ts,"oscal-version":"1.1.3"},"import-ap":{href:`${sn()}_AP.json`},results:[{uuid:crypto.randomUUID(),title:"Assessment-Ergebnis",description:'Ergebnisse',start:S.dateStart?`${S.dateStart}T00:00:00Z`:ts,end:S.dateEnd?`${S.dateEnd}T23:59:59Z`:ts,"reviewed-controls":{"control-selections":[{"include-controls":cids.map(c=>({"control-id":c}))}]},...(obs.length?{observations:obs}:{}),findings:fin,...(rsk.length?{risks:rsk}:{})}]}};
     dl(ar,`${sn()}_AR.json`);autoSave();


### PR DESCRIPTION
## Summary

Reworks the **`Baustein_2_Profile`** one-page app so it maps BSI Ed2023 Bausteine onto **real Grundschutz++ (G++) Anwenderkatalog controls** instead of producing custom controls, and adds chunked matching with prompt caching. Also includes two fixes to `pruefung_ap_ar`.

## Problem (Baustein_2_Profile)

The app produced **almost only custom controls** and had very low sentence-match rates:

- It loaded the **BSI Kernel** catalog, but the Zielobjekt profiles import IDs from the **G++ Anwenderkatalog** → control IDs never resolved.
- Stage 1 listed profiles via the **GitHub API** (`api.github.com/.../contents`), which rate-limits (HTTP 403) → no profile match → fell back to the deterministic **C.2 custom-control** path almost every run.
- Sentences were matched against the wrong/empty control set, with prose truncated to 400 chars.

## What changed

**New pipeline (build 0.8.1, prompt `v5-chunked`):**

1. **Stage 1 — LLM classification.** Sends the PDF start + the `target_object_categories.csv` list (name + Definition + Synonyme) → `{object_type: zielobjekt|prozess, zielobjekt_name, confidence, rationale}`, resolved to a category UUID. No GitHub-API dependency — everything loads via `raw.githubusercontent.com`.
2. **Stage 2 — correct pool + chunked sentence mapping.**
   - Candidate pool = `zielobjekt_controls.json[uuid]` (Zielobjekt) or the ISMS set (Prozess).
   - Control match-context uses the cheap **stripped descriptions** (`gpp_isms_stripped.md`, parsed to id/name/desc), falling back to catalog prose.
   - The pool is **chunked** (~100 controls/chunk, configurable). The prompt **prefix (instructions + all PDF sentences) is identical across a Baustein's chunk requests** and only the control-chunk varies at the end → **Gemini implicit prompt caching** reuses the prefix. The model returns only matched sentences per chunk; sentences are pre-seeded and merged as a union across chunks.
3. **Stage 3 — OSCAL profile with `modify.alters`.** Imports the matched G++ control IDs and embeds the **verbatim Ed2023 PDF sentences** at each matched control.

**Also:**
- OSCAL `{{ insert: param }}` placeholders are resolved so control prose is clean.
- **Token + cache tracking pill** in the topbar (`Σ <total> tok · cache <cached> (<%>)`) from `usageMetadata`, reset per run, with a per-stage breakdown tooltip.
- **Selectable/copyable raw-log textarea** toggle in the console.
- Migrates stale Kernel/GitHub-API URLs out of `localStorage`; removes the dead profile-index machinery and the now-meaningless threshold field.

**`pruefung_ap_ar`** (separate commits on this branch): resolve `local://` profile refs via file load/relative fetch; read detailed risk analysis from SSP back-matter.

## Testing

⚠️ Not yet verified live in this change — needs a manual run served over `http://localhost` (not `file://`, which blocks `fetch`/CORS).

- [x] On load: G++ Anwenderkatalog (~998 controls), Zielobjektkategorien, and ZO/ISMS pools auto-load (check the log console).
- [x] A Zielobjekt Baustein classifies to a category and produces a profile importing real G++ IDs (not custom controls).
- [x] A process Baustein classifies as `prozess` and maps against the ISMS pool.
- [x] The token pill shows a rising **cache %** across a Baustein's chunk requests (confirms prefix caching engages).
- [x] Downloaded profile contains `imports.include-controls.with-ids` + `modify.alters` with verbatim PDF text.

## Notes

- `hilfsdateien/gpp_stripped.md` is currently header-only (empty) — Zielobjekt prose comes from the Anwenderkatalog. Worth regenerating if the stripped file is wanted as context.
- The large PROZESS pool stems from a separate `Gpp-ai-tool` bug being fixed elsewhere; chunking handles any pool size.

## Summary

Two browser-only OSCAL tools in `One-Page-Apps/` get fixes and a new pipeline.
The headline changes: `pruefung_ap_ar.html` can finally resolve `local://`
profile references and now reads the detailed risk analysis from the SSP, and
`Baustein_2_Profile.html` gains a full G++ Anwenderkatalog classification pipeline.

## Changes

### `pruefung_ap_ar.html` — Assessment Plan & Results Generator

**1. Resolve `local://` profile references** (`e437a66`)
SSP component links reference profile definitions via `local://…json` hrefs.
The app did a raw `fetch("local://…")`, which the browser always rejects
(invalid scheme), so component definitions never loaded.
- New multi-file **“📁 Profile/Defs laden”** drop zone; parsed profiles are
  stored in `S.localDefs` keyed by filename.
- New `fetchDef()`: resolves `local://` from `S.localDefs` first, otherwise a
  relative fetch (works when served over http); `http(s)` URLs use a CORS fetch.
- New shared `applyDefData()` helper — `loadCompDefs` and `retryFailedDefs` no
  longer duplicate the parse/apply logic.
- Failure status hints at the manual loader for `local://` refs.
- Profiles may be loaded before *or* after the SSP; defs re-resolve on load.

**2. Read detailed risk analysis from SSP back-matter** (`a322afe`)
The base64-encoded `risk-analysis.json` in `back-matter` was never read, so
risks maintained in the SSP were lost in the generated AR.
- New `base64DecodeUnicode()` (UTF-8 safe) + `extractSSPRisks()`, mirroring the
  working reader in `ssp_ausfuellen.html`.
- `S.sspRisks` populated on SSP load; risk count shown in the SSP status.
- Each SSP risk is mapped to a valid OSCAL risk (`statement`/`status` required),
  with `likelihood`/`impact` as props and target component + mitigating controls
  in `remarks`, merged into `results[].risks`.
- `sspRisks` persisted across session save/restore.

### `Baustein_2_Profile.html` — G++ Anwenderkatalog profile builder

- **G++ Anwenderkatalog pipeline with LLM classification** (`9568b42`)
- **Chunked control-matching, prompt caching, token pill, log textarea** (`ad8b615`)

## Testing

- `local://` resolution and risk extraction verified by code review; the example
  back-matter base64 was decoded out-of-band and confirmed to parse to
  `{"risks":[…]}` and map to a valid OSCAL risk.
- Recommended manual check: open each tool, load a real SSP (one with `local://`
  profile links and a `risk-analysis.json` attachment), confirm component defs
  load and the generated AR contains the risks.

## Notes

- No session-format bump: both additions are backward compatible (`_v:9`
  unchanged; `localDefs` not persisted, `sspRisks` is additive).
- Follow-up idea: link SSP risks to the matching control findings via
  `related-risks` (using `mitigatingControls`) rather than standalone risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)