### PR TITLE
SdT-Nachzügler: Prop-Namen, Gefährdungs-Anzeige, BSI-Komponenten-Import

### DIFF
--- a/One-Page-Apps/GSpp-Viewer.html
+++ b/One-Page-Apps/GSpp-Viewer.html
@@ -765,7 +765,7 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
             const modal = stmtPart?.props?.find(p => p.name === 'modal_verb')?.value || "";
 			const action = stmtPart?.props?.find(p => p.name === 'action_word')?.value || "";
 			const result = stmtPart?.props?.find(p => p.name === 'result')?.value || "";
-			const precision = stmtPart?.props?.find(p => p.name === 'precision')?.value || "";
+			const precision = stmtPart?.props?.find(p => p.name === 'result_specification' || p.name === 'precision')?.value || "";
 			const targetObj = stmtPart?.props?.find(p => p.name === 'target_object_categories')?.value || "";
 
             if(modal) filterOptions.modalverb.add(modal);

--- a/One-Page-Apps/GSpp-Viewer.html
+++ b/One-Page-Apps/GSpp-Viewer.html
@@ -116,6 +116,8 @@
         /* BSI-Schutzziel-Props (security_targets.csv): Wert 1 = wirkt, Wert 2 = im Zentrum */
         .tag-sz { background: #eceff1; color: #455a64; border-color: #cfd8dc; }
         .tag-sz-strong { background: #455a64; color: #fff; border-color: #263238; }
+        /* Elementare Gefährdungen (threats-Prop, basethreats.csv) */
+        .tag-threat { background: #fff3e0; color: #b34700; border-color: #ffcc80; }
 
         /* Statement Box */
         .statement-box { background: #fff; border: 1px solid #eee; padding: 18px; border-radius: 8px; margin: 15px 0; }
@@ -244,6 +246,7 @@
                 <select id="filterModal" class="filter-select" onchange="applyFilters()"><option value="all">Jede Modalität</option></select>
                 <select id="filterHandlung" class="filter-select" onchange="applyFilters()"><option value="all">Alle Handlungen</option></select>
                 <select id="filterTag" class="filter-select" onchange="applyFilters()"><option value="all">Alle Tags</option></select>
+                <select id="filterThreat" class="filter-select" onchange="applyFilters()"><option value="all">Alle Gefährdungen</option></select>
                 <button class="reset-btn" onclick="resetFilters()">Filter zurücksetzen</button>
             </div>
         </div>
@@ -316,7 +319,10 @@
 
     <script>
         const apiKey = "";
-        let filterOptions = { class: new Set(), sec_level: new Set(), effort_level: new Set(), modalverb: new Set(), handlung: new Set(), tags: new Set() };
+        let filterOptions = { class: new Set(), sec_level: new Set(), effort_level: new Set(), modalverb: new Set(), handlung: new Set(), tags: new Set(), threat: new Set() };
+
+        // Elementare Gefährdungen (BSI basethreats.csv) — Namen für die threats-Prop-Badges.
+        const G0_THREATS = {'G 0.1':'Feuer','G 0.2':'Ungünstige klimatische Bedingungen','G 0.3':'Wasser','G 0.4':'Verschmutzung, Staub, Korrosion','G 0.5':'Naturkatastrophen','G 0.6':'Katastrophen im Umfeld','G 0.7':'Großereignisse im Umfeld','G 0.8':'Ausfall oder Störung der Stromversorgung','G 0.9':'Ausfall oder Störung von Kommunikationsnetzen','G 0.10':'Ausfall oder Störung von Versorgungsnetzen','G 0.11':'Ausfall oder Störung von Dienstleistern','G 0.12':'Elektromagnetische Störstrahlung','G 0.13':'Abfangen kompromittierender Strahlung','G 0.14':'Ausspähen von Informationen (Spionage)','G 0.15':'Abhören','G 0.16':'Diebstahl von Geräten, Datenträgern oder Dokumenten','G 0.17':'Verlust von Geräten, Datenträgern oder Dokumenten','G 0.18':'Fehlplanung oder fehlende Anpassung','G 0.19':'Offenlegung schützenswerter Informationen','G 0.20':'Informationen oder Produkte aus unzuverlässiger Quelle','G 0.21':'Manipulation von Hard- oder Software','G 0.22':'Manipulation von Informationen','G 0.23':'Unbefugtes Eindringen in IT-Systeme','G 0.24':'Zerstörung von Geräten oder Datenträgern','G 0.25':'Ausfall von Geräten oder Systemen','G 0.26':'Fehlfunktion von Geräten oder Systemen','G 0.27':'Ressourcenmangel','G 0.28':'Software-Schwachstellen oder -Fehler','G 0.29':'Verstoß gegen Gesetze oder Regelungen','G 0.30':'Unberechtigte Nutzung oder Administration von Geräten und Systemen','G 0.31':'Fehlerhafte Nutzung oder Administration von Geräten und Systemen','G 0.32':'Missbrauch von Berechtigungen','G 0.33':'Personalausfall','G 0.34':'Anschlag','G 0.35':'Nötigung, Erpressung oder Korruption','G 0.36':'Identitätsdiebstahl','G 0.37':'Abstreiten von Handlungen','G 0.38':'Missbrauch personenbezogener Daten','G 0.39':'Schadprogramme','G 0.40':'Verhinderung von Diensten (Denial of Service)','G 0.41':'Sabotage','G 0.42':'Social Engineering','G 0.43':'Einspielen von Nachrichten','G 0.44':'Unbefugtes Eindringen in Räumlichkeiten','G 0.45':'Datenverlust','G 0.46':'Integritätsverlust schützenswerter Informationen','G 0.47':'Schädliche Seiteneffekte IT-gestützter Angriffe'};
         let loadedCatalogs = [];
         let aiCache = {};
         // Vorberechnetes Mapping G++-Control -> passende BSI ED2023-Anforderungen
@@ -679,7 +685,7 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
             document.getElementById('clearAllBtn').style.display = 'none';
             document.getElementById('filterControls').style.display = 'none';
             loadedCatalogs = [];
-            filterOptions = { class: new Set(), sec_level: new Set(), effort_level: new Set(), modalverb: new Set(), handlung: new Set(), tags: new Set() };
+            filterOptions = { class: new Set(), sec_level: new Set(), effort_level: new Set(), modalverb: new Set(), handlung: new Set(), tags: new Set(), threat: new Set() };
             populateFilterUI();
         }
 
@@ -755,6 +761,11 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
             ].map(([name, label]) => ({ label, value: control.props?.find(p => p.name === name)?.value || '0' }))
              .filter(sz => sz.value !== '0');
 
+            // Elementare Gefährdungen (threats-Prop, kommaseparierte G 0.x-IDs aus basethreats.csv)
+            const threatsRaw = control.props?.find(p => p.name === 'threats')?.value || "";
+            const threatIds = threatsRaw ? threatsRaw.split(',').map(t => t.trim()).filter(t => t) : [];
+            threatIds.forEach(t => filterOptions.threat.add(t));
+
             if(cClass) filterOptions.class.add(cClass);
             if(sec) filterOptions.sec_level.add(sec);
             if(effort) filterOptions.effort_level.add(effort);
@@ -771,13 +782,14 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
             if(modal) filterOptions.modalverb.add(modal);
             if(action) filterOptions.handlung.add(action);
 
-            card.dataset.searchText = `${control.id} ${uuid} ${control.title} ${stmtPart?.prose || ""} ${modal} ${action} ${targetObj} ${tagsArray.join(' ')}`.toLowerCase();
+            card.dataset.searchText = `${control.id} ${uuid} ${control.title} ${stmtPart?.prose || ""} ${modal} ${action} ${targetObj} ${tagsArray.join(' ')} ${threatIds.map(t => `${t} ${G0_THREATS[t] || ''}`).join(' ')}`.toLowerCase();
             card.dataset.class = cClass;
             card.dataset.sec = sec;
             card.dataset.effort = effort;
             card.dataset.modal = modal;
             card.dataset.handlung = action;
             card.dataset.tags = JSON.stringify(tagsArray);
+            card.dataset.threats = JSON.stringify(threatIds);
 
             card.innerHTML = `
                 <div class="id-row"><span class="badge-id">${control.id}</span><span class="badge-class">${escapeHtml(cClass)}</span></div>
@@ -790,6 +802,7 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
                     ${action ? `<span class="tag tag-action">${escapeHtml(action)}</span>` : ''}
                     ${targetObj ? `<span class="tag tag-target">🎯 ${escapeHtml(targetObj)}</span>` : ''}
                     ${schutzziele.map(sz => `<span class="tag ${sz.value === '2' ? 'tag-sz-strong' : 'tag-sz'}" title="${sz.label}: ${sz.value === '2' ? 'steht im Zentrum der Anforderung' : 'Anforderung wirkt auf dieses Schutzziel'}">🛡 ${sz.label}${sz.value === '2' ? ' ●●' : ''}</span>`).join('')}
+                    ${threatIds.map(t => `<span class="tag tag-threat" title="${escapeHtml(G0_THREATS[t] || 'Elementare Gefährdung')}">⚠ ${escapeHtml(t)}</span>`).join('')}
                     ${tagsArray.map(t => `<span class="tag tag-tags">Tag: ${escapeHtml(t)}</span>`).join('')}
                 </div>
                 <div class="statement-box">
@@ -850,9 +863,10 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
             const fMod = document.getElementById('filterModal').value;
             const fHandlung = document.getElementById('filterHandlung').value;
             const fTag = document.getElementById('filterTag').value;
+            const fThreat = document.getElementById('filterThreat').value;
 
             // Prüfe, ob überhaupt ein Filter (inkl. Profil) aktiv ist
-            const anyFilterActive = (query !== "" || fClass !== "all" || fSec !== "all" || fEff !== "all" || fMod !== "all" || fHandlung !== "all" || fTag !== "all" || activeProfileIds !== null);
+            const anyFilterActive = (query !== "" || fClass !== "all" || fSec !== "all" || fEff !== "all" || fMod !== "all" || fHandlung !== "all" || fTag !== "all" || fThreat !== "all" || activeProfileIds !== null);
 
             document.querySelectorAll('.filterable-item, .filterable-container').forEach(el => {
                 el.classList.add('hidden');
@@ -872,6 +886,7 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
 
             document.querySelectorAll('.control-card').forEach(card => {
                 const cardTags = card.dataset.tags ? JSON.parse(card.dataset.tags) : [];
+                const cardThreats = card.dataset.threats ? JSON.parse(card.dataset.threats) : [];
 
                 // Beinhaltet jetzt die Prüfung gegen das Set activeProfileIds
                 const match = (!query || card.dataset.searchText.includes(query)) &&
@@ -881,6 +896,7 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
                               (fMod === 'all' || card.dataset.modal === fMod) &&
                               (fHandlung === 'all' || card.dataset.handlung === fHandlung) &&
                               (fTag === 'all' || cardTags.includes(fTag)) &&
+                              (fThreat === 'all' || cardThreats.includes(fThreat)) &&
                               (!activeProfileIds || activeProfileIds.has(card.id)); // NEU: Profil-Filter
 
                 if (match) {
@@ -923,16 +939,21 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
             fillSelect('filterModal', filterOptions.modalverb, "Modalität");
             fillSelect('filterHandlung', filterOptions.handlung, "Handlung");
             fillSelect('filterTag', filterOptions.tags, "Tag");
+            // Numerisch nach G 0.x sortieren, Anzeige mit Gefährdungsnamen
+            fillSelect('filterThreat', filterOptions.threat, "Gefährdung", {
+                sortFn: (a, b) => (parseFloat(a.replace('G 0.', '')) || 0) - (parseFloat(b.replace('G 0.', '')) || 0),
+                displayFn: t => `${t} — ${G0_THREATS[t] || 'Elementare Gefährdung'}`,
+            });
         }
 
-        function fillSelect(id, set, label) {
+        function fillSelect(id, set, label, opts = {}) {
             const sel = document.getElementById(id);
             if (!sel) return;
             const currentVal = sel.value;
-            Array.from(set).sort().forEach(v => {
+            Array.from(set).sort(opts.sortFn).forEach(v => {
                 if (!v) return;
                 const o = document.createElement('option');
-                o.value = v; o.textContent = v; sel.appendChild(o);
+                o.value = v; o.textContent = opts.displayFn ? opts.displayFn(v) : v; sel.appendChild(o);
             });
             if (set.has(currentVal)) sel.value = currentVal;
             else sel.value = 'all';
@@ -940,7 +961,7 @@ eine KI. Dein Satzbau ist Abwechslungsreich, konkret, präßise und du nutzt kei
 
         function resetFilters() {
             document.getElementById('searchInput').value = '';
-            ['filterClass', 'filterSec', 'filterEffort', 'filterModal', 'filterHandlung', 'filterTag'].forEach(id => document.getElementById(id).value = 'all');
+            ['filterClass', 'filterSec', 'filterEffort', 'filterModal', 'filterHandlung', 'filterTag', 'filterThreat'].forEach(id => document.getElementById(id).value = 'all');
 
             document.getElementById('profileSelect').value = '';
             document.getElementById('profileInfo').textContent = '';

--- a/One-Page-Apps/ssp_ausfuellen.html
+++ b/One-Page-Apps/ssp_ausfuellen.html
@@ -285,7 +285,7 @@
         if (n.includes('authenticity')) return { icon: icons.shield, color: 'text-green-200 bg-green-900/50 border-green-800', strongColor: 'text-green-100 bg-green-700/80 border-green-400', label: 'Authenticity', schutzziel: true };
         if (n.includes('phase')) return { icon: icons.clock, color: 'text-purple-200 bg-purple-900/50 border-purple-800', label: 'Phase' };
         if (n.includes('class') || n.includes('technical')) return { icon: icons.cube, color: 'text-slate-200 bg-slate-700 border-slate-600', label: 'Class' };
-        if (n.includes('modalverb')) return { icon: icons.alert, color: 'text-fuchsia-200 bg-fuchsia-900/60 border-fuchsia-700', label: 'Modalverb' };
+        if (n.includes('modal_verb') || n.includes('modalverb')) return { icon: icons.alert, color: 'text-fuchsia-200 bg-fuchsia-900/60 border-fuchsia-700', label: 'Modalverb' };
         if (n.includes('effort_level') || n.includes('aufwand')) return { icon: icons.zap, color: 'text-orange-200 bg-orange-900/60 border-orange-700', label: 'Aufwand' };
         if (n.includes('documentation') || n.includes('dokumentation')) return { icon: icons.doc, color: 'text-cyan-200 bg-cyan-900/60 border-cyan-700', label: 'Doku' };
         if (n.includes('ergebnis') || n.includes('result')) return { icon: icons.check, color: 'text-emerald-200 bg-emerald-900/60 border-emerald-700', label: 'Ergebnis' };
@@ -998,7 +998,7 @@
 
         let navHtml = '';
         let filterOpts = { status: new Set(['open', 'implemented', 'partial', 'planned', 'alternative', 'not-applicable']) };
-        const allowedFilters = ['status', 'modalverb', 'sec_level', 'class', 'phase', 'tags', 'tag'];
+        const allowedFilters = ['status', 'modal_verb', 'modalverb', 'sec_level', 'class', 'phase', 'tags', 'tag'];
         const addFilter = (k, v) => {
             if(!k || !v) return;
             const kl = k.toLowerCase();

--- a/One-Page-Apps/ssp_generator.html
+++ b/One-Page-Apps/ssp_generator.html
@@ -352,6 +352,8 @@
         const API_URL_NUTZERGEN = 'https://api.github.com/repos/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/contents/ED23-Baustein-profile/DE';
         const API_URL_GPLUS = 'https://api.github.com/repos/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/contents/Zielobjektkategorien/profile/regular';
         const API_URL_PRAKTIKEN = 'https://api.github.com/repos/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/contents/Zielobjektkategorien/profile/process';
+        // BSI implementation_layer: fertige Component-Definitions (Keycloak, Netzarchitektur, ...)
+        const API_URL_SDT_COMPONENTS = 'https://api.github.com/repos/BSI-Bund/Stand-der-Technik-Bibliothek/contents/implementation_layer';
         const PRAKTIKEN_FILE_SUFFIX = '_process_profile.json';
 
         // Praktik-Kürzel → Begriff. Fallback für die Anzeige, falls der Basis-Katalog (mit
@@ -609,6 +611,8 @@
             manualControls: new Set(),
             modifications: new Map(),
             components: [],
+            bsiComponents: [], // Importierte BSI-Component-Definitions (SdT implementation_layer)
+            altIdIndex: new Map(), // alt-identifier (UUID) -> G++ Control-ID, für das Mapping der SdT-Komponenten
             riskData: [],
             customControls: new Map(),
             aiDocuments: new Map(),
@@ -638,6 +642,7 @@
             await loadCachedAIDocuments();
             renderCatalogsList();
             fetchGitHubComponents();
+            fetchSdtComponents();
             // Prozess-Liste wird über switchMethodik('standard') unten passend zur Methodik geladen.
             setupSearchListeners();
             setupRiskTabListeners();
@@ -2275,6 +2280,8 @@ ${candidates.join('\n')}`;
                         if (i.props) {
                             const mv = i.props.find(isModalverbProp);
                             if (mv) modalverb = mv.value;
+                            const alt = i.props.find(p => p.name === 'alt-identifier');
+                            if (alt && alt.value) bpState.altIdIndex.set(String(alt.value).trim().toLowerCase(), i.id);
                         }
                         if (i.parts) {
                             const prosePart = i.parts.find(p => p.name === 'statement' || p.prose);
@@ -2531,6 +2538,16 @@ ${candidates.join('\n')}`;
                     </div>
                 </div>
 
+                <div class="mb-6 p-5 bg-slate-900/80 border border-amber-700/60 rounded-xl shadow-inner">
+                    <h3 class="text-sm font-bold text-amber-400 uppercase mb-2">3b. BSI-Komponenten (SdT implementation_layer, Optional)</h3>
+                    <p class="text-xs text-slate-400 mb-4">Fertige Component-Definitions aus der Stand-der-Technik-Bibliothek (z.B. Keycloak, Netzarchitektur, Passwortrichtlinie). Sie werden als SSP-Komponenten übernommen und liefern vorbefüllte Umsetzungsbeschreibungen für die abgedeckten G++-Anforderungen.</p>
+                    <div class="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-3 mb-3">
+                        <select id="dd-sdt-comp" class="w-full px-3 py-2 bg-slate-900 border border-slate-600 rounded-lg text-sm text-white"><option value="">Lade BSI-Komponenten...</option></select>
+                        <button onclick="addBsiComponent()" class="px-5 py-2 bg-amber-600 text-white font-medium rounded-lg hover:bg-amber-500 transition-colors text-sm shadow-md">Komponente importieren</button>
+                    </div>
+                    <ul id="bsi-components-list" class="space-y-2"></ul>
+                </div>
+
                 <div class="pt-2">
                     <h3 class="text-sm font-bold text-slate-300 uppercase mb-2">4. Optionale Muster-Assets</h3>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
@@ -2721,6 +2738,78 @@ ${candidates.join('\n')}`;
                 bpState.praktiken.delete(url);
             }
             renderTailoredList();
+        }
+
+        // --- BSI-Komponenten (SdT implementation_layer) ---
+        async function fetchSdtComponents() {
+            const dd = document.getElementById('dd-sdt-comp');
+            if (!dd) return;
+            try {
+                const dirs = await (await fetch(API_URL_SDT_COMPONENTS)).json();
+                dd.innerHTML = '<option value="" disabled selected>BSI-Komponente wählen...</option>';
+                for (const d of (Array.isArray(dirs) ? dirs : []).filter(i => i.type === 'dir')) {
+                    try {
+                        const files = await (await fetch(d.url)).json();
+                        (Array.isArray(files) ? files : [])
+                            .filter(f => f.name.endsWith('-component_definition.json'))
+                            .forEach(f => dd.appendChild(new Option(f.name.replace('-component_definition.json', ''), f.download_url)));
+                    } catch (e) { console.warn('SdT-Komponenten-Ordner nicht lesbar:', d.name, e); }
+                }
+            } catch (e) {
+                console.warn('SdT implementation_layer nicht erreichbar', e);
+                dd.innerHTML = '<option value="">BSI-Komponenten nicht erreichbar</option>';
+            }
+        }
+
+        async function addBsiComponent() {
+            const dd = document.getElementById('dd-sdt-comp');
+            const url = dd?.value;
+            if (!url) return alert('Bitte zuerst eine BSI-Komponente auswählen.');
+            if (bpState.bsiComponents.some(bc => bc.source === url)) return alert('Diese BSI-Komponente ist bereits importiert.');
+            try {
+                const data = await (await fetch(url)).json();
+                const cd = data['component-definition'];
+                if (!cd) throw new Error('Keine component-definition im Dokument.');
+                const name = dd.options[dd.selectedIndex].text;
+                let mapped = 0, unmapped = 0;
+                const components = (cd.components || []).map(c => {
+                    const impls = [];
+                    (c['control-implementations'] || []).forEach(ci => {
+                        (ci['implemented-requirements'] || []).forEach(req => {
+                            // control-id ist "_<uuid>" aus dem Kernel-Katalog; Mapping auf die
+                            // G++-ID über das alt-identifier-Prop des Anwenderkatalogs.
+                            const key = String(req['control-id'] || '').replace(/^_/, '').trim().toLowerCase();
+                            const gppId = bpState.altIdIndex.get(key);
+                            if (gppId) { impls.push({ gppId, text: req.description || '' }); mapped++; }
+                            else unmapped++;
+                        });
+                    });
+                    return { uuid: c.uuid || crypto.randomUUID(), title: c.title || 'Komponente', type: c.type || 'software', description: c.description || '', impls };
+                });
+                bpState.bsiComponents.push({ uuid: cd.uuid || crypto.randomUUID(), name, source: url, components, mapped, unmapped });
+                renderBsiComponentsList();
+            } catch (e) {
+                alert('BSI-Komponente konnte nicht geladen werden: ' + e.message);
+            }
+        }
+
+        function removeBsiComponent(uuid) {
+            bpState.bsiComponents = bpState.bsiComponents.filter(bc => bc.uuid !== uuid);
+            renderBsiComponentsList();
+        }
+
+        function renderBsiComponentsList() {
+            const ul = document.getElementById('bsi-components-list');
+            if (!ul) return;
+            const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+            ul.innerHTML = bpState.bsiComponents.map(bc => `
+                <li class="flex items-center justify-between bg-slate-800 border border-amber-800/60 rounded-lg px-4 py-2 text-sm">
+                    <span class="text-white">
+                        <span class="font-semibold text-amber-300">${esc(bc.name)}</span>
+                        <span class="text-slate-400 ml-2">${bc.components.length} Komponente(n), ${bc.mapped} Anforderungen auf G++ gemappt${bc.unmapped ? `, ${bc.unmapped} ohne Mapping` : ''}</span>
+                    </span>
+                    <button onclick="removeBsiComponent('${esc(bc.uuid)}')" class="text-red-400 hover:text-red-300 font-bold ml-3" title="Entfernen">✕</button>
+                </li>`).join('');
         }
 
         async function fetchGitHubComponents() {
@@ -3996,6 +4085,18 @@ ${candidates.join('\n')}`;
                 });
             });
 
+            // BSI-Komponenten (SdT implementation_layer) als SSP-Komponenten übernehmen.
+            bpState.bsiComponents.forEach(bc => bc.components.forEach(c => {
+                sspComponents.push({
+                    uuid: c.uuid,
+                    type: c.type,
+                    title: `${bc.name}: ${c.title}`,
+                    description: c.description,
+                    status: { state: "operational" },
+                    links: [{ href: bc.source, rel: "component-definition" }]
+                });
+            }));
+
             bpState.components.forEach(c => {
                 sspComponents.push({
                     uuid: c.id,
@@ -4271,6 +4372,31 @@ ${candidates.join('\n')}`;
                 }
                 return requirement;
             }).filter(req => req["by-components"].length > 0);
+
+            // BSI-Komponenten: vorbefüllte Umsetzungsbeschreibungen aus dem implementation_layer
+            // in die implemented-requirements mergen (per G++-Control-ID, gemappt via alt-identifier).
+            if (bpState.bsiComponents.length > 0) {
+                const reqByControl = new Map(reqs.map(r => [r['control-id'], r]));
+                bpState.bsiComponents.forEach(bc => bc.components.forEach(c => (c.impls || []).forEach(impl => {
+                    let req = reqByControl.get(impl.gppId);
+                    if (!req) {
+                        req = {
+                            uuid: crypto.randomUUID(),
+                            'control-id': impl.gppId,
+                            description: 'Umsetzung durch BSI-Komponente aus der Stand-der-Technik-Bibliothek (implementation_layer).',
+                            'by-components': []
+                        };
+                        reqByControl.set(impl.gppId, req);
+                        reqs.push(req);
+                    }
+                    req['by-components'].push({
+                        'component-uuid': c.uuid,
+                        uuid: crypto.randomUUID(),
+                        description: impl.text,
+                        'implementation-status': { state: 'implemented' }
+                    });
+                })));
+            }
 
             const metadata = {
                 title: `${t} - Muster-SSP`,


### PR DESCRIPTION
Drei Pakete, um die SdT-Änderungen vollständig in den Apps zu nutzen:

## 1. Veraltete Prop-Namen (März-Umbenennung)
- **GSpp-Viewer:** `precision` → `result_specification` (mit Fallback) — „Präzisierung" rendert wieder (450 Controls, vorher 0)
- **ssp_ausfuellen:** Badge-Matcher und Filter-Whitelist um `modal_verb` ergänzt

## 2. Elementare Gefährdungen (threats-Prop, `basethreats.csv`)
- **GSpp-Viewer:** Badge je G 0.x am Control (Gefährdungsname als Tooltip, eingebettete G0-Map), eigener Gefährdungs-Filter (numerisch sortiert, mit Namen), Volltextsuche findet IDs und Namen
- Live verifiziert: 1.965 Badges, 43 Gefährdungen im Filter, Filter „G 0.14" → 30 Controls

## 3. BSI-Komponenten (implementation_layer)
- **ssp_generator:** Neue Sektion „3b. BSI-Komponenten" — Dropdown lädt die Component-Definitions (Keycloak, Netzarchitektur, Passwortrichtlinie, …) per GitHub-API. Import mappt die Kernel-UUIDs über `alt-identifier` auf G++-IDs; beim SSP-Export werden Komponenten + vorbefüllte Umsetzungsbeschreibungen in die `implemented-requirements` gemergt.
- Live verifiziert: Keycloak → 3 Komponenten, 43/43 Anforderungen gemappt, Export enthält alle by-components
- `ssp_generator_ed23` bleibt bewusst unverändert (nutzt die alten ED23-Kataloge ohne G++-alt-identifier — braucht keine Änderungen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)