### PR TITLE
Terraform für die GCP-Testumgebung des Datenbank-Backends

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell-Skripte behalten LF, auch wenn sie unter Windows ausgecheckt werden:
+# infra/terraform/startup.sh wird per file() eingelesen und auf einer Linux-VM
+# ausgeführt — mit CRLF scheitert schon die Shebang-Zeile.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@
 __pycache__/
 *.pyc
 .venv/
+
+# Terraform: State enthält die erzeugten Passwörter, tfvars die eigene IP.
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+terraform.tfvars
+

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,119 @@
+# Testumgebung für das Datenbank-Backend (GCP)
+
+Baut die Referenzinstallation aus [`PLAN_Datenbank-Backend.md`](../../PLAN_Datenbank-Backend.md)
+auf einer einzelnen Compute-Engine-VM: PostgreSQL, GoTrue und PostgREST als
+Supabase-Compose-Stack, davor optional Caddy als TLS-Endpunkt und statischer
+Host für die Werkzeuge aus `GS++-oscal-app/`.
+
+Bewusst **kein** Cloud SQL und **kein** Cloud Run: das wären VPC-Connector,
+Cloud-SQL-Proxy und zwei Dienstbereitstellungen zusätzlich — und der Aufbau
+wiche von dem ab, was Anwender nach Phase 5 selbst betreiben. Fehler, die hier
+auftreten, sollen dieselben sein, die dort auftreten.
+
+## Was entsteht
+
+| Ressource | Zweck |
+|---|---|
+| VPC + Subnetz `10.10.0.0/24` | eigenes Netz, Flow-Logs an |
+| Firewall `allow-iap` | 22, 5432, 8000 **nur** aus `35.235.240.0/20` (IAP) |
+| Firewall `allow-acme` / `allow-https` | nur mit `domain`: 80 offen für Let's Encrypt, 443 für `allowed_cidrs` |
+| Feste externe IP | damit `API_EXTERNAL_URL` ein Stop/Start überlebt |
+| VM `gpp-supabase` | Debian 12, Shielded VM, Docker + Compose-Stack |
+| Dienstkonto | `logWriter`, `metricWriter`, `secretAccessor` auf genau drei Secrets |
+| Drei Secrets | Postgres-Passwort, `JWT_SECRET`, Studio-Passwort |
+| A-Record | optional, nur bei Cloud DNS im selben Projekt |
+| Budget-Alarm | optional, 50/90/100 Prozent |
+
+Port 5432 ist **nicht** öffentlich erreichbar — er steht nur im IAP-Bereich
+offen, damit Migrationen per `psql` durch den Tunnel laufen können.
+
+## Voraussetzungen
+
+* Ein GCP-Projekt mit aktiver Abrechnung.
+* Auf dem eigenen Rechner: `terraform`, `gcloud`, und
+  `gcloud auth application-default login`.
+* Eigene Rolle im Projekt: `roles/owner` genügt fürs Erste; minimal sind
+  `compute.admin`, `iam.serviceAccountAdmin`, `secretmanager.admin`,
+  `serviceusage.serviceUsageAdmin` und `resourcemanager.projectIamAdmin`.
+* Für SSH zusätzlich `roles/compute.osLogin` und `roles/iap.tunnelResourceAccessor`.
+* Das Budget nur mit `roles/billing.costsManager` auf dem Abrechnungskonto.
+
+## Anlegen
+
+```bash
+cd infra/terraform && cp terraform.tfvars.example terraform.tfvars && terraform init && terraform apply
+```
+
+Der erste Boot lädt Docker-Images und braucht ein paar Minuten. Fortschritt:
+
+```bash
+gcloud compute ssh gpp-supabase --zone europe-west3-b --tunnel-through-iap -- 'sudo tail -f /var/log/gpp-startup.log'
+```
+
+## Phase 1 abnehmen — ohne einen offenen Port
+
+`domain` bleibt leer. Kong per Tunnel auf den eigenen Rechner holen:
+
+```bash
+gcloud compute start-iap-tunnel gpp-supabase 8000 --local-host-port=localhost:8000 --zone europe-west3-b
+```
+
+`ANON_KEY` und `SERVICE_ROLE_KEY` stehen in `/opt/gpp/supabase/.env` auf der VM.
+Danach ist die Abnahme aus dem Plan — zwei parallele `curl`-Sitzungen um die
+Sperre, `leser` scheitert am Schreiben, `bearbeiter` an `kind = 'ar'` — direkt
+gegen `http://localhost:8000/rest/v1/...` fahrbar. Studio liegt unter
+`http://localhost:8000` (Benutzer `gpp`, Passwort aus dem Secret).
+
+Migrationen einspielen, zweiter Tunnel:
+
+```bash
+gcloud compute start-iap-tunnel gpp-supabase 5432 --local-host-port=localhost:5433 --zone europe-west3-b
+```
+
+```bash
+psql "postgresql://postgres:$(gcloud secrets versions access latest --secret=gpp-postgres-password)@localhost:5433/postgres" -f schema.sql
+```
+
+## Phase 2 vorbereiten — Hostname und statischer Host
+
+`domain` und `allowed_cidrs` setzen, `terraform apply`, dann die Werkzeuge
+hochladen:
+
+```bash
+gcloud compute scp --recurse --tunnel-through-iap --zone europe-west3-b ../../GS++-oscal-app/. gpp-supabase:/opt/gpp/app/
+```
+
+Caddy liefert `/` aus diesem Verzeichnis und reicht `/rest/*`, `/auth/*`,
+`/realtime/*` und `/storage/*` an Kong weiter. Werkzeuge und API liegen damit
+unter **demselben Ursprung**: die CORS-Frage entfällt, statt konfiguriert zu
+werden, und `Origin: null` aus `file://` muss nirgends zugelassen werden — die
+Phase-0-Frage 1 des Plans ist damit praktisch beantwortet, ohne dass der
+Doppelklick-Betrieb für alle anderen etwas verliert.
+
+Studio ist über den öffentlichen Namen absichtlich **nicht** erreichbar; dafür
+bleibt der Tunnel.
+
+## Kosten und Aufräumen
+
+Rund 45–55 € im Monat in `europe-west3` für `e2-standard-2`, 50 GB Platte und
+die feste IP. Zwischen den Testtagen:
+
+```bash
+gcloud compute instances stop gpp-supabase --zone europe-west3-b
+```
+
+Der Stack kommt beim nächsten Start über `gpp-supabase.service` von selbst
+wieder hoch; es fallen dann nur Platte und IP an. Vollständig entfernen mit
+`terraform destroy` — die aktivierten APIs bleiben absichtlich stehen.
+
+## Was hier nicht drin ist
+
+* **Ein IdP für Pfad B.** Zum Testen genügt ein Keycloak-Container neben dem
+  Stack — kein GCP-Bedarf, und Gruppen-Claims für `org`/`gpp_role` lassen sich
+  frei erfinden. Entra ID erst, wenn gegen das getestet werden soll, was
+  Anwender tatsächlich betreiben; dafür wird der Hostname von oben gebraucht.
+* **Sicherung.** Für eine Wegwerfinstanz absichtlich nicht eingebaut. Sobald
+  Inhalte drin stehen, die weh tun: Snapshot-Zeitplan auf die Bootplatte.
+* **Härtung fürs Produktivsystem.** Das hier ist eine Testinstanz. Die
+  Zufallspasswörter liegen im Terraform-State — der gehört entsprechend
+  behandelt (Remote-State im GCS-Bucket mit Versionierung, nicht ins Git).

--- a/infra/terraform/dns.tf
+++ b/infra/terraform/dns.tf
@@ -1,0 +1,40 @@
+resource "google_dns_record_set" "app" {
+  count = var.dns_managed_zone != "" && local.tls_enabled ? 1 : 0
+
+  name         = "${var.domain}."
+  managed_zone = var.dns_managed_zone
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [google_compute_address.vm.address]
+}
+
+resource "google_billing_budget" "this" {
+  count = var.billing_account != "" ? 1 : 0
+
+  billing_account = var.billing_account
+  display_name    = "${var.name_prefix}-supabase-test"
+
+  budget_filter {
+    projects = ["projects/${data.google_project.this.number}"]
+  }
+
+  amount {
+    specified_amount {
+      units = tostring(var.budget_amount)
+    }
+  }
+
+  # 50 / 90 / 100 Prozent an die Rechnungsempfänger des Kontos.
+  dynamic "threshold_rules" {
+    for_each = [0.5, 0.9, 1.0]
+    content {
+      threshold_percent = threshold_rules.value
+    }
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+data "google_project" "this" {
+  project_id = var.project_id
+}

--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -1,0 +1,94 @@
+resource "google_project_service" "required" {
+  for_each = toset(compact([
+    "compute.googleapis.com",
+    "iap.googleapis.com",
+    "secretmanager.googleapis.com",
+    "oslogin.googleapis.com",
+    var.dns_managed_zone != "" ? "dns.googleapis.com" : "",
+    var.billing_account != "" ? "billingbudgets.googleapis.com" : "",
+  ]))
+
+  service = each.value
+
+  # Beim Zerstören der Testumgebung sollen keine APIs im Projekt abgeschaltet
+  # werden, die daneben noch jemand nutzt.
+  disable_on_destroy = false
+}
+
+resource "google_compute_network" "vpc" {
+  name                    = "${var.name_prefix}-vpc"
+  auto_create_subnetworks = false
+  depends_on              = [google_project_service.required]
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${var.name_prefix}-subnet"
+  ip_cidr_range = "10.10.0.0/24"
+  region        = var.region
+  network       = google_compute_network.vpc.id
+
+  # Damit Verbindungsversuche in den Logs auftauchen, ohne dass ein
+  # Flow-Log-Berg entsteht.
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Der einzige Verwaltungszugang: IAP-TCP-Forwarding aus dem festen Google-Netz.
+# 22 für SSH, 5432 für psql-Migrationen durch den Tunnel, 8000 für Kong —
+# damit Phase 1 vollständig ohne einen offenen Port abnehmbar ist.
+resource "google_compute_firewall" "iap" {
+  name          = "${var.name_prefix}-allow-iap"
+  network       = google_compute_network.vpc.name
+  direction     = "INGRESS"
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = [local.tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "5432", "8000"]
+  }
+}
+
+# Port 80 trägt ausschließlich die ACME-Challenge und die Umleitung nach
+# HTTPS. Let's Encrypt prüft aus wechselnden Netzen, eine Einschränkung wäre
+# hier nur Kosmetik mit Ausfallrisiko.
+resource "google_compute_firewall" "acme" {
+  count = local.tls_enabled ? 1 : 0
+
+  name          = "${var.name_prefix}-allow-acme"
+  network       = google_compute_network.vpc.name
+  direction     = "INGRESS"
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = [local.tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+}
+
+resource "google_compute_firewall" "https" {
+  count = local.tls_enabled ? 1 : 0
+
+  name          = "${var.name_prefix}-allow-https"
+  network       = google_compute_network.vpc.name
+  direction     = "INGRESS"
+  source_ranges = var.allowed_cidrs
+  target_tags   = [local.tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+}
+
+# Feste Adresse: API_EXTERNAL_URL und der DNS-Record sollen ein Stop/Start der
+# VM überleben.
+resource "google_compute_address" "vm" {
+  name       = "${var.name_prefix}-ip"
+  region     = var.region
+  depends_on = [google_project_service.required]
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,37 @@
+output "external_ip" {
+  description = "Feste öffentliche Adresse der VM — Ziel des A-Records, falls DNS extern gepflegt wird."
+  value       = google_compute_address.vm.address
+}
+
+output "ssh" {
+  description = "SSH ohne offenen Port 22."
+  value       = "gcloud compute ssh ${google_compute_instance.supabase.name} --zone ${var.zone} --project ${var.project_id} --tunnel-through-iap"
+}
+
+output "tunnel_api" {
+  description = "Kong/PostgREST auf den eigenen Rechner holen — der Weg für die curl-Abnahme aus Phase 1."
+  value       = "gcloud compute start-iap-tunnel ${google_compute_instance.supabase.name} 8000 --local-host-port=localhost:8000 --zone ${var.zone} --project ${var.project_id}"
+}
+
+output "tunnel_postgres" {
+  description = "psql für die Migrationen aus Phase 1."
+  value       = "gcloud compute start-iap-tunnel ${google_compute_instance.supabase.name} 5432 --local-host-port=localhost:5433 --zone ${var.zone} --project ${var.project_id}"
+}
+
+output "upload_app" {
+  description = "Die neun Werkzeuge auf den statischen Host schieben (nur mit gesetztem domain sinnvoll)."
+  value       = "gcloud compute scp --recurse --tunnel-through-iap --zone ${var.zone} --project ${var.project_id} ../../GS++-oscal-app/. ${google_compute_instance.supabase.name}:/opt/gpp/app/"
+}
+
+output "secret_commands" {
+  description = "Die erzeugten Zugangsdaten auslesen. ANON_KEY und SERVICE_ROLE_KEY stehen in /opt/gpp/supabase/.env auf der VM."
+  value = {
+    for k, v in google_secret_manager_secret.this :
+    k => "gcloud secrets versions access latest --secret=${v.secret_id} --project=${var.project_id}"
+  }
+}
+
+output "app_url" {
+  description = "Ursprung, unter dem Werkzeuge und API gemeinsam liegen."
+  value       = local.tls_enabled ? "https://${var.domain}" : "(kein domain gesetzt — nur über den IAP-Tunnel auf http://localhost:8000)"
+}

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -1,0 +1,73 @@
+# Zeichensatz bewusst ohne Sonderzeichen: die Werte laufen im Startskript durch
+# sed und landen in Verbindungs-URLs. Die Entropie holt die Länge.
+resource "random_password" "postgres" {
+  length  = 40
+  special = false
+}
+
+resource "random_password" "jwt_secret" {
+  length  = 64
+  special = false
+}
+
+resource "random_password" "dashboard" {
+  length  = 32
+  special = false
+}
+
+locals {
+  secrets = {
+    postgres-password = random_password.postgres.result
+    jwt-secret        = random_password.jwt_secret.result
+    dashboard-password = random_password.dashboard.result
+  }
+}
+
+resource "google_secret_manager_secret" "this" {
+  for_each = local.secrets
+
+  secret_id = "${var.name_prefix}-${each.key}"
+
+  replication {
+    user_managed {
+      replicas {
+        location = var.region
+      }
+    }
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_secret_manager_secret_version" "this" {
+  for_each = local.secrets
+
+  secret      = google_secret_manager_secret.this[each.key].id
+  secret_data = each.value
+}
+
+resource "google_service_account" "vm" {
+  account_id   = "${var.name_prefix}-supabase-vm"
+  display_name = "GS++ Supabase-Testinstanz"
+}
+
+# Nur Lesezugriff auf genau diese drei Secrets — kein projektweites
+# secretAccessor.
+resource "google_secret_manager_secret_iam_member" "vm" {
+  for_each = google_secret_manager_secret.this
+
+  secret_id = each.value.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.vm.email}"
+}
+
+resource "google_project_iam_member" "vm" {
+  for_each = toset([
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.vm.email}"
+}

--- a/infra/terraform/startup.sh
+++ b/infra/terraform/startup.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Startskript der Supabase-Testinstanz. Läuft als root bei jedem Boot und ist
+# idempotent: die .env wird genau einmal erzeugt, alles Weitere ist ein
+# Abgleich. Protokoll: /var/log/gpp-startup.log, zusätzlich im Serial Port.
+#
+set -euo pipefail
+exec > >(tee -a /var/log/gpp-startup.log | logger -t gpp-startup -s 2>/dev/console) 2>&1
+
+STACK_DIR=/opt/gpp/supabase
+APP_DIR=/opt/gpp/app
+MD=http://metadata.google.internal/computeMetadata/v1
+
+meta() {
+  curl -sf -H "Metadata-Flavor: Google" "$MD/instance/attributes/$1" || true
+}
+
+PROJECT="$(curl -sf -H "Metadata-Flavor: Google" "$MD/project/project-id")"
+DOMAIN="$(meta gpp-domain)"
+SUPABASE_REF="$(meta gpp-supabase-ref)"
+SECRET_PG="$(meta gpp-secret-pg)"
+SECRET_JWT="$(meta gpp-secret-jwt)"
+SECRET_DASH="$(meta gpp-secret-dash)"
+
+secret() {
+  local token
+  token="$(curl -sf -H "Metadata-Flavor: Google" \
+    "$MD/instance/service-accounts/default/token" \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')"
+  curl -sf -H "Authorization: Bearer $token" \
+    "https://secretmanager.googleapis.com/v1/projects/$PROJECT/secrets/$1/versions/latest:access" \
+    | python3 -c 'import sys,json,base64;print(base64.b64decode(json.load(sys.stdin)["payload"]["data"]).decode(),end="")'
+}
+
+# Supabase erwartet ANON_KEY und SERVICE_ROLE_KEY als HS256-JWT über demselben
+# JWT_SECRET, mit dem PostgREST prüft. Zehn Jahre Laufzeit ist das, was der
+# offizielle Generator ausstellt — es sind Dienstschlüssel, keine Sitzungen.
+gen_jwt() {
+  python3 - "$1" "$2" <<'PY'
+import base64, hmac, hashlib, json, sys, time
+
+secret, role = sys.argv[1], sys.argv[2]
+
+def b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+def part(obj) -> str:
+    return b64(json.dumps(obj, separators=(",", ":")).encode())
+
+iat = int(time.time())
+head = part({"alg": "HS256", "typ": "JWT"})
+body = part({"role": role, "iss": "supabase", "iat": iat, "exp": iat + 315360000})
+sig = b64(hmac.new(secret.encode(), f"{head}.{body}".encode(), hashlib.sha256).digest())
+print(f"{head}.{body}.{sig}", end="")
+PY
+}
+
+# --------------------------------------------------------------------------
+# Pakete
+# --------------------------------------------------------------------------
+export DEBIAN_FRONTEND=noninteractive
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "== Docker installieren"
+  apt-get update -qq
+  apt-get install -y -qq ca-certificates curl gnupg git
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/debian/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update -qq
+  apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-compose-plugin
+  systemctl enable --now docker
+fi
+
+if [ -n "$DOMAIN" ] && ! command -v caddy >/dev/null 2>&1; then
+  echo "== Caddy installieren"
+  apt-get install -y -qq debian-keyring debian-archive-keyring apt-transport-https
+  curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" \
+    > /etc/apt/sources.list.d/caddy-stable.list
+  apt-get update -qq
+  apt-get install -y -qq caddy
+fi
+
+# --------------------------------------------------------------------------
+# Supabase-Compose-Verzeichnis holen (nur docker/, ohne Repo-Historie)
+# --------------------------------------------------------------------------
+mkdir -p /opt/gpp "$APP_DIR"
+
+if [ ! -f /opt/gpp/.checked-out ]; then
+  echo "== supabase/docker auschecken ($SUPABASE_REF)"
+  rm -rf /opt/gpp/supabase-src
+  # --depth 1 --branch klappt nur bei Zweigen und Tags; für einen Commit-SHA
+  # greift der zweite Versuch ohne Tiefenbegrenzung.
+  git clone --filter=blob:none --no-checkout --depth 1 \
+    --branch "$SUPABASE_REF" https://github.com/supabase/supabase /opt/gpp/supabase-src \
+    || git clone --filter=blob:none --no-checkout \
+         https://github.com/supabase/supabase /opt/gpp/supabase-src
+  git -C /opt/gpp/supabase-src sparse-checkout set --cone docker
+  git -C /opt/gpp/supabase-src checkout "$SUPABASE_REF"
+  mkdir -p "$STACK_DIR"
+  cp -a /opt/gpp/supabase-src/docker/. "$STACK_DIR/"
+  git -C /opt/gpp/supabase-src rev-parse HEAD > /opt/gpp/.checked-out
+fi
+
+cd "$STACK_DIR"
+
+# --------------------------------------------------------------------------
+# .env — einmalig aus der mitgelieferten Vorlage, dann gezielt überschrieben.
+# Die Vorlage zu patchen statt sie zu ersetzen hält das Ganze über
+# Supabase-Versionen hinweg am Leben: neue Pflichtvariablen kommen mit.
+# --------------------------------------------------------------------------
+if [ ! -f .env ]; then
+  echo "== .env erzeugen"
+  cp .env.example .env
+
+  PG_PASS="$(secret "$SECRET_PG")"
+  JWT_SECRET="$(secret "$SECRET_JWT")"
+  DASH_PASS="$(secret "$SECRET_DASH")"
+  ANON_KEY="$(gen_jwt "$JWT_SECRET" anon)"
+  SERVICE_KEY="$(gen_jwt "$JWT_SECRET" service_role)"
+
+  if [ -n "$DOMAIN" ]; then
+    PUBLIC_URL="https://$DOMAIN"
+  else
+    PUBLIC_URL="http://localhost:8000"
+  fi
+
+  setenv() {
+    local key="$1" value="$2"
+    if grep -q "^$key=" .env; then
+      python3 - "$key" "$value" <<'PY'
+import sys, pathlib
+key, value = sys.argv[1], sys.argv[2]
+p = pathlib.Path(".env")
+lines = p.read_text().splitlines()
+p.write_text("\n".join(f"{key}={value}" if l.startswith(f"{key}=") else l for l in lines) + "\n")
+PY
+    else
+      echo "$key=$value" >> .env
+    fi
+  }
+
+  setenv POSTGRES_PASSWORD    "$PG_PASS"
+  setenv JWT_SECRET           "$JWT_SECRET"
+  setenv ANON_KEY             "$ANON_KEY"
+  setenv SERVICE_ROLE_KEY     "$SERVICE_KEY"
+  setenv DASHBOARD_USERNAME   "gpp"
+  setenv DASHBOARD_PASSWORD   "$DASH_PASS"
+  setenv SITE_URL             "$PUBLIC_URL"
+  setenv API_EXTERNAL_URL     "$PUBLIC_URL"
+  setenv SUPABASE_PUBLIC_URL  "$PUBLIC_URL"
+  setenv SECRET_KEY_BASE      "$(head -c 48 /dev/urandom | base64 | tr -d '=+/' | head -c 64)"
+  setenv VAULT_ENC_KEY        "$(head -c 32 /dev/urandom | base64 | tr -d '=+/' | head -c 32)"
+
+  chmod 600 .env
+fi
+
+# --------------------------------------------------------------------------
+# Stack starten
+# --------------------------------------------------------------------------
+echo "== Compose-Stack starten"
+docker compose pull -q || true
+docker compose up -d
+
+cat > /etc/systemd/system/gpp-supabase.service <<'UNIT'
+[Unit]
+Description=GS++ Supabase-Stack
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/gpp/supabase
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable gpp-supabase.service
+
+# --------------------------------------------------------------------------
+# Caddy: Werkzeuge und API unter demselben Ursprung. Damit erübrigt sich die
+# CORS-Konfiguration, statt sie zu erfordern — und Phase-0-Frage 1 des Plans
+# ist beantwortet, ohne den Offline-Betrieb per Doppelklick anzutasten.
+# Studio bleibt bewusst draußen; es ist nur durch den IAP-Tunnel auf :8000
+# erreichbar.
+# --------------------------------------------------------------------------
+if [ -n "$DOMAIN" ]; then
+  echo "== Caddy konfigurieren für $DOMAIN"
+  cat > /etc/caddy/Caddyfile <<CADDY
+$DOMAIN {
+	encode gzip
+
+	@api path /rest/* /auth/* /realtime/* /storage/* /functions/*
+	handle @api {
+		reverse_proxy localhost:8000
+	}
+
+	handle {
+		root * $APP_DIR
+		file_server browse
+	}
+
+	log {
+		output file /var/log/caddy/access.log
+	}
+}
+CADDY
+  mkdir -p /var/log/caddy
+  chown -R caddy:caddy /var/log/caddy
+  systemctl enable caddy
+  systemctl reload-or-restart caddy
+fi
+
+echo "== fertig"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,19 @@
+# Kopieren nach terraform.tfvars und ausfüllen.
+
+project_id = "gpp-db-test"
+
+# Phase 1 (curl-Abnahme): domain und allowed_cidrs leer lassen. Dann steht
+# kein Port offen, alles läuft durch den IAP-Tunnel.
+
+# Phase 2 und später — der Browser muss die DB erreichen:
+# domain        = "gpp-test.example.de"
+# allowed_cidrs = ["203.0.113.7/32"]   # eigene öffentliche Adresse
+# dns_managed_zone = "example-de"      # nur bei Cloud DNS im selben Projekt
+
+# Grundregel 8: sobald das mehr als ein erster Versuch ist, hier einen
+# Commit-SHA statt "master" eintragen.
+# supabase_ref = "master"
+
+# Nur mit Rechten auf dem Abrechnungskonto:
+# billing_account = "0X0X0X-0X0X0X-0X0X0X"
+# budget_amount   = 50

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,113 @@
+variable "project_id" {
+  description = "Bestehendes GCP-Projekt, in dem die Testumgebung entsteht."
+  type        = string
+}
+
+variable "region" {
+  description = "Region. Voreinstellung Frankfurt — die Testdaten sind zwar Wegwerfware, aber der Kontext ist BSI."
+  type        = string
+  default     = "europe-west3"
+}
+
+variable "zone" {
+  description = "Zone innerhalb der Region."
+  type        = string
+  default     = "europe-west3-b"
+}
+
+variable "name_prefix" {
+  description = "Präfix für alle Ressourcennamen."
+  type        = string
+  default     = "gpp"
+}
+
+variable "machine_type" {
+  description = <<-EOT
+    e2-standard-2 (8 GB) trägt den vollständigen Supabase-Compose-Stack.
+    e2-medium (4 GB) reicht nur, wenn analytics/realtime/storage abgeschaltet
+    werden — der mitgelieferte Compose-Stand verdrahtet die aber als
+    depends_on, deshalb ist Trimmen mehr Arbeit als der Preisunterschied wert.
+  EOT
+  type        = string
+  default     = "e2-standard-2"
+}
+
+variable "boot_disk_gb" {
+  description = "Größe der Bootplatte in GB (Images, Postgres-Daten und Logs liegen darauf)."
+  type        = number
+  default     = 50
+}
+
+variable "domain" {
+  description = <<-EOT
+    Vollständiger Hostname, unter dem Caddy die Werkzeuge und die API
+    ausliefert, z. B. "gpp-test.example.de". Leer lassen für Phase 1: dann
+    bleibt die VM ohne offene Ports und alles läuft durch den IAP-Tunnel.
+    Sobald der Browser die DB erreichen soll (Phase 2), wird der Name
+    gebraucht — ohne TLS kein fetch() von einer HTTPS-Seite.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "allowed_cidrs" {
+  description = <<-EOT
+    Quell-Netze, die 443 erreichen dürfen. Nur relevant, wenn "domain" gesetzt
+    ist. Bewusst keine Voreinstellung auf 0.0.0.0/0. Port 80 steht unabhängig
+    davon offen — die ACME-Prüfung von Let's Encrypt kommt aus wechselnden
+    Netzen und lässt sich nicht sinnvoll einschränken; auf 80 liegt nur die
+    Challenge und die Umleitung nach HTTPS.
+  EOT
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = !contains(var.allowed_cidrs, "0.0.0.0/0")
+    error_message = "0.0.0.0/0 ist für eine Testinstanz mit echten Zugangsdaten nicht vorgesehen. Trage die eigene öffentliche IP als /32 ein."
+  }
+}
+
+variable "dns_managed_zone" {
+  description = "Name einer bestehenden Cloud-DNS-Zone im selben Projekt. Leer lassen, wenn der A-Record beim Registrar gepflegt wird."
+  type        = string
+  default     = ""
+}
+
+variable "supabase_ref" {
+  description = <<-EOT
+    Git-Ref des supabase/supabase-Repos, aus dem das docker/-Verzeichnis
+    geholt wird. Grundregel 8 des Projekts (Quellen sind commit-gepinnt) gilt
+    auch hier: für alles jenseits eines ersten Versuchs einen Commit-SHA
+    eintragen, nicht "master".
+  EOT
+  type        = string
+  default     = "master"
+}
+
+variable "billing_account" {
+  description = "Abrechnungskonto-ID für das Budget-Alarm. Leer lassen, wenn keine Rechte darauf bestehen — dann entfällt das Budget."
+  type        = string
+  default     = ""
+}
+
+variable "budget_amount" {
+  description = "Monatliches Budget in ganzen Währungseinheiten des Abrechnungskontos."
+  type        = number
+  default     = 50
+}
+
+locals {
+  tls_enabled = var.domain != ""
+  tag         = "${var.name_prefix}-supabase"
+}
+
+# Ein Hostname ohne freigegebene Quell-Netze wäre eine Adresse, die niemand
+# erreicht.
+resource "terraform_data" "guard_allowed_cidrs" {
+  lifecycle {
+    precondition {
+      condition     = !local.tls_enabled || length(var.allowed_cidrs) > 0
+      error_message = "Mit gesetztem \"domain\" muss \"allowed_cidrs\" mindestens ein Netz enthalten, sonst erreicht niemand Port 443."
+    }
+  }
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/infra/terraform/vm.tf
+++ b/infra/terraform/vm.tf
@@ -1,0 +1,60 @@
+resource "google_compute_instance" "supabase" {
+  name         = "${var.name_prefix}-supabase"
+  machine_type = var.machine_type
+  zone         = var.zone
+  tags         = [local.tag]
+
+  # Beim Zerstören soll nichts an einem laufenden Prozess scheitern.
+  allow_stopping_for_update = true
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+      size  = var.boot_disk_gb
+      type  = "pd-balanced"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnet.id
+
+    access_config {
+      nat_ip = google_compute_address.vm.address
+    }
+  }
+
+  shielded_instance_config {
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
+  service_account {
+    email  = google_service_account.vm.email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = {
+    enable-oslogin = "TRUE"
+
+    gpp-domain       = var.domain
+    gpp-supabase-ref = var.supabase_ref
+    gpp-secret-pg    = google_secret_manager_secret.this["postgres-password"].secret_id
+    gpp-secret-jwt   = google_secret_manager_secret.this["jwt-secret"].secret_id
+    gpp-secret-dash  = google_secret_manager_secret.this["dashboard-password"].secret_id
+  }
+
+  metadata_startup_script = file("${path.module}/startup.sh")
+
+  depends_on = [
+    google_secret_manager_secret_version.this,
+    google_secret_manager_secret_iam_member.vm,
+    terraform_data.guard_allowed_cidrs,
+  ]
+
+  lifecycle {
+    # Ein geändertes Startskript soll die VM nicht ersetzen — es läuft bei
+    # jedem Boot erneut und ist idempotent geschrieben.
+    ignore_changes = [metadata_startup_script]
+  }
+}


### PR DESCRIPTION
Terraform für eine Testumgebung des in [`PLAN_Datenbank-Backend.md`](https://github.com/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/blob/main/PLAN_Datenbank-Backend.md) beschriebenen Backends. Nur die Beschreibung — hier wird nichts ausgerollt, der Aufbau findet in einer eigenen Sitzung statt.

## Was drin ist

`infra/terraform/` legt eine einzelne Compute-Engine-VM an, auf der der Supabase-Compose-Stack (PostgreSQL, GoTrue, PostgREST, Kong) läuft, dazu Netz, Firewall, feste IP, Dienstkonto, drei Secrets und optional A-Record und Budget-Alarm. Ein Startskript installiert Docker, holt `supabase/docker`, erzeugt die `.env` und startet den Stack; ein systemd-Unit bringt ihn nach einem Stop/Start wieder hoch.

## Zwei Entscheidungen, die den Aufbau prägen

**Eine VM statt Cloud SQL plus Cloud Run.** Die cloud-native Variante kostet VPC-Connector, Cloud-SQL-Proxy und zwei Dienstbereitstellungen zusätzlich — und der Aufbau wiche von dem ab, was Anwender nach Phase 5 selbst betreiben. Fehler beim Testen sollen dieselben sein wie im Betrieb. Der Umzug lohnt sich, wenn die Sache produktiv wird, nicht währenddessen.

**Caddy liefert Werkzeuge und API unter demselben Ursprung.** `/rest/*` und `/auth/*` gehen an Kong, alles andere ist der statische Ordner mit den neun Werkzeugen. Damit entfällt die CORS-Frage, statt konfiguriert zu werden, und ein `Origin: null` aus `file://` muss nirgends zugelassen werden. Das ist der praktische Teil der Antwort auf **Phase-0-Frage 1** des Plans; entschieden ist damit nichts, aber der Offline-Betrieb per Doppelklick bleibt für alle anderen unangetastet.

## Zugangswege

Ohne gesetztes `domain` steht **kein Port** offen — SSH, `psql` und Kong laufen durch IAP-TCP-Forwarding aus `35.235.240.0/20`. Die curl-Abnahme aus Phase 1 (zwei parallele Sitzungen um die Sperre, `leser` scheitert am Schreiben, `bearbeiter` an `kind = 'ar'`) ist damit vollständig fahrbar, bevor ein Hostname existiert. Erst für Phase 2 werden `domain` und `allowed_cidrs` gesetzt; dann öffnet sich 443 für die eingetragenen Netze und 80 für die ACME-Prüfung, die aus wechselnden Netzen kommt und sich nicht sinnvoll einschränken lässt.

Studio ist über den öffentlichen Namen absichtlich nicht erreichbar, nur durch den Tunnel.

## Zugangsdaten

Postgres-Passwort, `JWT_SECRET` und Studio-Passwort entstehen als `random_password`, liegen im Secret Manager und werden beim Boot gezogen. `ANON_KEY` und `SERVICE_ROLE_KEY` signiert das Startskript aus dem `JWT_SECRET` — die im Supabase-Repo mitgelieferten Vorgaben sind öffentlich bekannt und dürfen nicht stehen bleiben. Das Dienstkonto hat `secretAccessor` auf genau diese drei Secrets, nicht projektweit.

## Für Reviewer

* **Der State enthält die Zufallspasswörter.** `.gitignore` deckt `*.tfstate` und `terraform.tfvars` ab; sobald das mehr als ein Einzelversuch wird, gehört der State in einen versionierten GCS-Bucket.
* **`supabase_ref` steht auf `master`.** Grundregel 8 (Quellen sind commit-gepinnt) verlangt hier einen SHA, sobald es ernst wird. Der Kommentar an der Variablen sagt das, erzwingen tut es nichts.
* **`.gitattributes` ist neu** und hält `*.sh` auf LF. `startup.sh` wird per `file()` eingelesen und auf einer Linux-VM ausgeführt; mit CRLF scheitert schon die Shebang-Zeile.
* **Nicht angewendet.** `terraform validate` ist gegen diese Dateien nicht gelaufen — die CLI ist auf dem Rechner nicht installiert. Der erste `apply` ist der erste echte Test.
* Kosten: rund 45–55 € im Monat in `europe-west3`; VM stoppen zwischen den Testtagen lässt nur Platte und IP übrig.

## Nicht im Umfang

Ein IdP für Pfad B (zum Testen genügt ein Keycloak-Container neben dem Stack, kein GCP-Bedarf), Sicherung, und die Migrationen selbst — Tabellen, RLS-Policies, `set_locks` und `artefact_save` aus Phase 1 sind ein eigener Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
